### PR TITLE
feat(root): Implement Typeahead and Tag Components

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -15,6 +15,8 @@ export default [
       Checkbox: "src/form/input/checkbox/Checkbox.tsx",
       Radio: "src/form/input/radio/Radio.tsx",
       RadioGroup: "src/form/input/radio/group/RadioGroup.tsx",
+      TypeaheadInput: "src/form/input/typeahead/TypeaheadInput.tsx",
+      TypeaheadSelect: "src/select/typeahead/TypeaheadSelect.tsx",
       Dropdown: "src/dropdown/Dropdown.tsx",
       Button: "src/button/Button.tsx",
       Spinner: "src/spinner/Spinner.tsx"

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -22,21 +22,21 @@ export default [
       List: "src/list/List.tsx",
       Button: "src/button/Button.tsx",
       FileUploadButton: "src/button/file-upload/FileUploadButton.tsx",
-      Spinner: "src/spinner/Spinner.tsx",
+      Spinner: "src/spinner/Spinner.tsx"
     },
     output: {
       dir: "dist",
-      format: 'cjs',
+      format: "cjs"
     },
     plugins: [
       reactSvg(),
       terser(),
       eslint({
         fix: true,
-        exclude: ["./src/**/**.scss", "./src/**/**.svg"],
+        exclude: ["./src/**/**.scss", "./src/**/**.svg"]
       }),
       stylelint({
-        "ignoreFiles": ["**/*.ts", "**/*.js"]
+        ignoreFiles: ["**/*.ts", "**/*.js"]
       }),
       postcss(),
       typescript({

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -12,14 +12,17 @@ export default [
       index: "src/index.ts",
       FormField: "src/form/field/FormField.tsx",
       Input: "src/form/input/Input.tsx",
+      FileInput: "src/form/input/file/FileInput.tsx",
       Checkbox: "src/form/input/checkbox/Checkbox.tsx",
       Radio: "src/form/input/radio/Radio.tsx",
       RadioGroup: "src/form/input/radio/group/RadioGroup.tsx",
       TypeaheadInput: "src/form/input/typeahead/TypeaheadInput.tsx",
       TypeaheadSelect: "src/select/typeahead/TypeaheadSelect.tsx",
       Dropdown: "src/dropdown/Dropdown.tsx",
+      List: "src/list/List.tsx",
       Button: "src/button/Button.tsx",
-      Spinner: "src/spinner/Spinner.tsx"
+      FileUploadButton: "src/button/file-upload/FileUploadButton.tsx",
+      Spinner: "src/spinner/Spinner.tsx",
     },
     output: {
       dir: "dist",

--- a/src/button/Button.tsx
+++ b/src/button/Button.tsx
@@ -6,7 +6,7 @@ import classNames from "classnames";
 import Spinner from "../spinner/Spinner";
 
 export interface ButtonProps {
-  testid: string;
+  testid?: string;
   children: React.ReactNode;
   onClick?: React.ReactEventHandler<HTMLButtonElement>;
   onMouseOver?: React.ReactEventHandler<HTMLButtonElement>;

--- a/src/button/Button.tsx
+++ b/src/button/Button.tsx
@@ -1,6 +1,6 @@
 import "./_button.scss";
 
-import React, {useEffect, useRef} from "react";
+import React from "react";
 import classNames from "classnames";
 
 import Spinner from "../spinner/Spinner";
@@ -53,23 +53,17 @@ function Button({
     inactive: isButtonDisabled,
     pending: shouldDisplaySpinner
   });
-  const buttonRef = useRef<HTMLButtonElement>(null);
-
-  useEffect(() => {
-    if (shouldFocus && buttonRef.current) {
-      buttonRef.current.focus();
-    }
-  }, [shouldFocus]);
 
   return (
     <button
-      ref={buttonRef}
       id={id}
       data-testid={testid}
       tabIndex={tabIndex}
       className={containerClassName}
       type={type}
       lang={lang}
+      // eslint-disable-next-line jsx-a11y/no-autofocus
+      autoFocus={shouldFocus}
       onClick={handleClick}
       onMouseOver={handleMouseOver}
       onMouseDown={onMouseDown}

--- a/src/button/_button.scss
+++ b/src/button/_button.scss
@@ -3,7 +3,7 @@
 
 .button {
   display: block;
-  
+
   width: 150px;
   height: 35px;
 

--- a/src/button/file-upload/FileUploadButton.tsx
+++ b/src/button/file-upload/FileUploadButton.tsx
@@ -1,11 +1,14 @@
 import "./_file-upload-button.scss";
 
 import React from "react";
+import classNames from "classnames";
+
 import FileInput, {FileInputProps} from "../../form/input/file/FileInput";
 
 export interface FileUploadButtonProps {
   fileInputProps: Omit<FileInputProps, "children" | "onChange"> & {children?: never};
   children: React.ReactNode;
+  customClassName?: string;
   onFileSelect?: (
     files: React.SyntheticEvent<HTMLInputElement>["currentTarget"]["files"]
   ) => void;
@@ -14,12 +17,15 @@ export interface FileUploadButtonProps {
 function FileUploadButton({
   fileInputProps,
   onFileSelect,
-  children
+  children,
+  customClassName
 }: FileUploadButtonProps) {
+  const containerClassName = classNames("file-upload-button", customClassName);
+
   return (
     <FileInput
       {...fileInputProps}
-      customClassName={"file-upload-button"}
+      customClassName={containerClassName}
       onChange={handleFileSelect}>
       {children}
     </FileInput>

--- a/src/button/file-upload/FileUploadButton.tsx
+++ b/src/button/file-upload/FileUploadButton.tsx
@@ -1,0 +1,37 @@
+import "./_file-upload-button.scss";
+
+import React from "react";
+import FileInput, {FileInputProps} from "../../form/input/file/FileInput";
+
+interface FileUploadButtonProps {
+  fileInputProps: Omit<FileInputProps, "children" | "onChange"> & {children?: never};
+  children: React.ReactNode;
+  onFileSelect?: (
+    files: React.SyntheticEvent<HTMLInputElement>["currentTarget"]["files"]
+  ) => void;
+}
+
+function FileUploadButton({
+  fileInputProps,
+  onFileSelect,
+  children
+}: FileUploadButtonProps) {
+  return (
+    <FileInput
+      {...fileInputProps}
+      customClassName={"file-upload-button"}
+      onChange={handleFileSelect}>
+      {children}
+    </FileInput>
+  );
+
+  function handleFileSelect(event: React.SyntheticEvent<HTMLInputElement>) {
+    const {files} = event.currentTarget;
+
+    if (onFileSelect && files?.length) {
+      onFileSelect(files);
+    }
+  }
+}
+
+export default FileUploadButton;

--- a/src/button/file-upload/FileUploadButton.tsx
+++ b/src/button/file-upload/FileUploadButton.tsx
@@ -3,7 +3,7 @@ import "./_file-upload-button.scss";
 import React from "react";
 import FileInput, {FileInputProps} from "../../form/input/file/FileInput";
 
-interface FileUploadButtonProps {
+export interface FileUploadButtonProps {
   fileInputProps: Omit<FileInputProps, "children" | "onChange"> & {children?: never};
   children: React.ReactNode;
   onFileSelect?: (

--- a/src/button/file-upload/_file-upload-button.scss
+++ b/src/button/file-upload/_file-upload-button.scss
@@ -1,0 +1,3 @@
+.file-upload-button {
+  width: 200px;
+}

--- a/src/core/utils/arrayUtils.ts
+++ b/src/core/utils/arrayUtils.ts
@@ -1,0 +1,17 @@
+function filterOutItemsByKey<T extends {[x: string]: any}>(
+  array: T[],
+  key: keyof T,
+  items: T[]
+): T[] {
+  const itemsToFilterOut = items.map((item) => item[key]);
+
+  return array.reduce<T[]>((finalArray, item) => {
+    if (!itemsToFilterOut.includes(item[key])) {
+      finalArray.push(item);
+    }
+
+    return finalArray;
+  }, []);
+}
+
+export {filterOutItemsByKey};

--- a/src/core/utils/hooks/debounce.tsx
+++ b/src/core/utils/hooks/debounce.tsx
@@ -1,0 +1,26 @@
+import React from "react";
+
+function useDebounce(debouncedHandler: any, initialValue: any, delay: number) {
+  const [value, setValue] = React.useState(initialValue);
+  const currentValueRef = React.useRef(value);
+
+  React.useEffect(() => {
+    let handler: any;
+
+    if (currentValueRef.current !== value) {
+      handler = setTimeout(() => {
+        debouncedHandler(value);
+      }, delay);
+
+      currentValueRef.current = value;
+    }
+
+    return () => {
+      clearTimeout(handler);
+    };
+  }, [currentValueRef, debouncedHandler, value, delay]);
+
+  return [value, setValue];
+}
+
+export default useDebounce;

--- a/src/dropdown/Dropdown.tsx
+++ b/src/dropdown/Dropdown.tsx
@@ -31,7 +31,7 @@ import useOnClickOutside from "../core/utils/hooks/onClickOutside";
 export type MenuVisibilityChangeHandlerTypeArgument = "open" | "closed";
 
 export interface DropdownProps<OptionIdShape> {
-  testid: string;
+  testid?: string;
   header?: React.ReactNode;
   placeholder?: string;
   options: DropdownOption<OptionIdShape>[];

--- a/src/dropdown/_dropdown.scss
+++ b/src/dropdown/_dropdown.scss
@@ -10,11 +10,11 @@ $dropdown-header-horizontal-padding: 8px;
   .dropdown-header-button {
     width: 100%;
     height: 40px;
-  
+
     background-color: white;
     border: 1px solid $light-grey;
     border-radius: $small-radius-size;
-  
+
     &:focus {
       border: 1px solid $grey;
       outline: none;
@@ -104,6 +104,12 @@ $dropdown-header-horizontal-padding: 8px;
   &:focus {
     outline: none;
   }
+
+  svg {
+    path {
+      fill: $grey;
+    }
+  }
 }
 
 .dropdown-header-button-text {
@@ -114,12 +120,6 @@ $dropdown-header-horizontal-padding: 8px;
   color: $dark-grey;
 
   text-align: left;
-}
-
-svg {
-  path {
-    fill: $grey;
-  }
 }
 
 .dropdown-header-button-default-content {

--- a/src/dropdown/list/DropdownList.tsx
+++ b/src/dropdown/list/DropdownList.tsx
@@ -11,7 +11,7 @@ import DropdownListItem, {
 import {computeScrollAmountToMakeChildVisible} from "../../core/utils/domUtils";
 
 interface DropdownListProps<OptionIdShape extends string> {
-  testid: string;
+  testid?: string;
   options: DropdownOption<OptionIdShape>[];
   selectedOption: TDropdownSelectedOption<OptionIdShape>;
   focusedOption: TDropdownSelectedOption<OptionIdShape>;

--- a/src/dropdown/list/_dropdown-list.scss
+++ b/src/dropdown/list/_dropdown-list.scss
@@ -4,7 +4,7 @@
 .dropdown-list {
   width: 100%;
 
-  box-sizing: border;
+  box-sizing: border-box;
 
   padding: 0;
 
@@ -14,5 +14,5 @@
 }
 
 .dropdown-empty-message {
-  padding: 20px;
+  padding: 0 15px;
 }

--- a/src/dropdown/list/item/DropdownListItem.tsx
+++ b/src/dropdown/list/item/DropdownListItem.tsx
@@ -24,7 +24,7 @@ export type TDropdownSelectedOption<Id = string, Context = any> =
   | undefined;
 
 interface DropdownListItemProps<OptionIdShape = string> {
-  testid: string;
+  testid?: string;
   option: DropdownOption<OptionIdShape>;
   selectedOption: TDropdownSelectedOption<OptionIdShape>;
   focusedOption?: TDropdownSelectedOption<OptionIdShape>;

--- a/src/dropdown/list/item/DropdownListItem.tsx
+++ b/src/dropdown/list/item/DropdownListItem.tsx
@@ -5,15 +5,15 @@ import classNames from "classnames";
 
 export interface DropdownOption<Id = string, Context = any> {
   id: Id;
-  customClassName?: string;
   title: string;
+  customClassName?: string;
   CustomContent?: JSX.Element;
   icon?: React.ReactNode;
   subtitle?: string;
   context?: Context;
 }
 
-export type TDropdownOptionSelectHandler<Id = string, Context = any> = (
+export type DropdownOptionSelectHandler<Id = string, Context = any> = (
   option: DropdownOption<Id, Context> | null,
   event?: React.SyntheticEvent<HTMLLIElement>
 ) => void;
@@ -28,9 +28,9 @@ interface DropdownListItemProps<OptionIdShape = string> {
   option: DropdownOption<OptionIdShape>;
   selectedOption: TDropdownSelectedOption<OptionIdShape>;
   focusedOption?: TDropdownSelectedOption<OptionIdShape>;
-  onSelect: TDropdownOptionSelectHandler<OptionIdShape>;
-  onFocus: TDropdownOptionSelectHandler<OptionIdShape>;
-  onKeyDown?: TDropdownOptionSelectHandler<OptionIdShape>;
+  onSelect: DropdownOptionSelectHandler<OptionIdShape>;
+  onFocus: DropdownOptionSelectHandler<OptionIdShape>;
+  onKeyDown?: DropdownOptionSelectHandler<OptionIdShape>;
   onMouseDown?: React.ReactEventHandler<HTMLLIElement>;
   onMouseUp?: React.ReactEventHandler<HTMLLIElement>;
   canSelectAlreadySelected?: boolean;

--- a/src/form/field/FormField.tsx
+++ b/src/form/field/FormField.tsx
@@ -4,17 +4,26 @@ import React from "react";
 import classNames from "classnames";
 import FormFieldMessageRow from "./message-row/FormFieldMessageRow";
 
-interface FormFieldProps {
+export interface FormFieldProps {
   children: React.ReactNode;
-  labelledBy?: string;
   label?: string;
-  className?: string;
+  labelledBy?: string;
+  labelFor?: string;
+  customClassName?: string;
   helperMessages?: Array<string>;
   errorMessages?: Array<string>;
 }
 
 function FormField(props: FormFieldProps) {
-  const {labelledBy, label, className, children, errorMessages, helperMessages} = props;
+  const {
+    label,
+    labelledBy,
+    labelFor,
+    customClassName,
+    children,
+    errorMessages,
+    helperMessages
+  } = props;
   const hasErrorMessage = Boolean(errorMessages?.length);
   const hasHelperMessage = Boolean(helperMessages?.length);
   const formFieldClassName = classNames(
@@ -22,18 +31,16 @@ function FormField(props: FormFieldProps) {
     {
       "has-error": hasErrorMessage
     },
-    className
+    customClassName
   );
 
   return (
     <div className={formFieldClassName}>
-      {Boolean(label) && (
-        <label id={labelledBy} className={"form-field-label"}>
-          {label}
-        </label>
-      )}
+      <label id={labelledBy} htmlFor={labelFor} className={"form-field-label"}>
+        <span className={"form-field-label-text"}>{label}</span>
 
-      {children}
+        {children}
+      </label>
 
       {hasErrorMessage &&
         errorMessages?.map((message) => (

--- a/src/form/field/FormField.tsx
+++ b/src/form/field/FormField.tsx
@@ -37,7 +37,7 @@ function FormField(props: FormFieldProps) {
   return (
     <div className={formFieldClassName}>
       <label id={labelledBy} htmlFor={labelFor} className={"form-field-label"}>
-        <span className={"form-field-label-text"}>{label}</span>
+        {Boolean(label) && <span className={"form-field-label-text"}>{label}</span>}
 
         {children}
       </label>

--- a/src/form/field/_form-field.scss
+++ b/src/form/field/_form-field.scss
@@ -5,11 +5,14 @@
   
   .form-field-label {
     display: block;
+  }
 
+  .form-field-label-text {
+    display: block;
+    
     margin-bottom: 8px;
 
-    font-size: 12px;
-    font-weight: 600;
-    text-transform: uppercase;
+    font-size: inherit;
+    font-weight: inherit;
   }
 }

--- a/src/form/input/Input.tsx
+++ b/src/form/input/Input.tsx
@@ -6,7 +6,9 @@ import classNames from "classnames";
 type InputType = "text" | "email" | "password" | "number" | "hidden" | "url";
 
 interface InputProps {
+  testid?: string;
   name: string;
+  id?: string;
   onChange: React.ReactEventHandler<HTMLInputElement>;
   type?: InputType;
   value?: string;
@@ -23,12 +25,13 @@ interface InputProps {
   rightIcon?: React.ReactNode;
   isDisabled?: boolean;
   hasError?: boolean;
-  className?: string;
+  customClassName?: string;
   inputContainerRef?: React.RefObject<HTMLDivElement>;
 }
 
 function Input(props: InputProps) {
   const {
+    testid,
     name,
     type = "text",
     value,
@@ -40,7 +43,7 @@ function Input(props: InputProps) {
     isDisabled,
     hasError,
     onFocus,
-    className,
+    customClassName,
     onBlur,
     onKeyUp,
     onKeyDown,
@@ -50,14 +53,18 @@ function Input(props: InputProps) {
     inputContainerRef,
     ...rest
   } = props;
-  const inputContainerClassName = classNames("input-container", className);
+  const inputContainerClassName = classNames("input-container", customClassName);
   const inputClassName = classNames("input", {
     disabled: isDisabled,
     "has-error": hasError
   });
 
   return (
-    <div ref={inputContainerRef} role={role} className={inputContainerClassName}>
+    <div
+      ref={inputContainerRef}
+      role={role}
+      className={inputContainerClassName}
+      data-testid={testid}>
       {leftIcon && <span className={"input-container-left-icon"}>{leftIcon}</span>}
 
       <input

--- a/src/form/input/Input.tsx
+++ b/src/form/input/Input.tsx
@@ -3,9 +3,9 @@ import "./_input.scss";
 import React from "react";
 import classNames from "classnames";
 
-type InputType = "text" | "email" | "password" | "number" | "hidden" | "url";
+type InputType = "text" | "email" | "password" | "number" | "tel" | "hidden" | "url";
 
-interface InputProps {
+export interface InputProps {
   testid?: string;
   name: string;
   id?: string;
@@ -16,6 +16,7 @@ interface InputProps {
   onBlur?: React.ReactEventHandler<HTMLInputElement>;
   onKeyDown?: React.KeyboardEventHandler<HTMLInputElement>;
   onKeyUp?: React.KeyboardEventHandler<HTMLInputElement>;
+  onInput?: React.KeyboardEventHandler<HTMLInputElement>;
   placeholder?: string;
   min?: number;
   max?: number;
@@ -47,6 +48,7 @@ function Input(props: InputProps) {
     onBlur,
     onKeyUp,
     onKeyDown,
+    onInput,
     leftIcon,
     rightIcon,
     role,
@@ -84,6 +86,7 @@ function Input(props: InputProps) {
         disabled={isDisabled}
         onKeyDown={onKeyDown}
         onKeyUp={onKeyUp}
+        onInput={onInput}
         {...rest}
       />
 

--- a/src/form/input/Input.tsx
+++ b/src/form/input/Input.tsx
@@ -5,7 +5,7 @@ import classNames from "classnames";
 
 type InputType = "text" | "email" | "password" | "number" | "tel" | "hidden" | "url";
 
-export interface InputProps {
+export interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
   testid?: string;
   name: string;
   id?: string;

--- a/src/form/input/_input.scss
+++ b/src/form/input/_input.scss
@@ -1,25 +1,29 @@
 @import "../../ui/reference/_colors.scss";
 @import "../../ui/reference/_measurement.scss";
 
+$input-height: 45px;
+
 .input-container {
-  display: grid;
-  grid-auto-columns: 1fr 40px;
+  display: flex;
+  align-items: center;
 
   width: 100%;
 
+  .input-container-left-icon,
   .input-container-right-icon {
     display: flex;
     align-items: center;
     justify-content: center;
 
-    grid-column: 2;
+    width: 40px;
+    height: $input-height;
   }
 }
 
 .input {
-  height: 45px;
+  height: $input-height;
   
-  grid-column: 1;
+  flex: 1;
 
   padding: 0 14px;
 
@@ -28,7 +32,8 @@
   border: 1px solid $light-grey;
   border-radius: $small-radius-size;
   
-  font-size: 14px;
+  font-size: inherit;
+  font-weight: inherit;
 
   &::placeholder {
     color: $grey;

--- a/src/form/input/_input.scss
+++ b/src/form/input/_input.scss
@@ -1,9 +1,25 @@
 @import "../../ui/reference/_colors.scss";
 @import "../../ui/reference/_measurement.scss";
 
+.input-container {
+  display: grid;
+  grid-auto-columns: 1fr 40px;
+
+  width: 100%;
+
+  .input-container-right-icon {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+
+    grid-column: 2;
+  }
+}
+
 .input {
-  width: 300px;
   height: 45px;
+  
+  grid-column: 1;
 
   padding: 0 14px;
 
@@ -19,7 +35,7 @@
   }
 
   &:focus {
-    outline: 1px solid $grey;
+    outline: none;
   }
 
   &:disabled {
@@ -31,9 +47,5 @@
 
   &.has-error {
     border: 1px solid $red;
-
-    &:focus {
-      outline: 1px solid $red;
-    }
   }
 }

--- a/src/form/input/checkbox/Checkbox.tsx
+++ b/src/form/input/checkbox/Checkbox.tsx
@@ -6,7 +6,7 @@ import React from "react";
 import classNames from "classnames";
 
 export interface CheckboxInputItem {
-  testid: string;
+  testid?: string;
   id: string;
   content: React.ReactNode;
   inputProps: {

--- a/src/form/input/checkbox/Checkbox.tsx
+++ b/src/form/input/checkbox/Checkbox.tsx
@@ -21,15 +21,22 @@ export interface CheckboxInputProps {
   onSelect: (name: string, item: CheckboxInputItem) => void;
   isSelected: boolean;
   isDisabled?: boolean;
+  customClassName?: string;
 }
 
-function CheckboxInput({item, onSelect, isSelected, isDisabled}: CheckboxInputProps) {
+function CheckboxInput({
+  item,
+  onSelect,
+  customClassName,
+  isSelected,
+  isDisabled
+}: CheckboxInputProps) {
   const {
     inputProps: {name, value, htmlFor},
     testid,
     content
   } = item;
-  const containerClassName = classNames("checkbox-input-label", {
+  const containerClassName = classNames("checkbox-input-label", customClassName, {
     selected: isSelected,
     disabled: isDisabled
   });

--- a/src/form/input/checkbox/_checkbox.scss
+++ b/src/form/input/checkbox/_checkbox.scss
@@ -86,6 +86,8 @@
   width: 20px;
   height: 20px;
 
+  flex-shrink: 0;
+
   margin-right: 10px;
 
   border: 1px solid $black;

--- a/src/form/input/checkbox/_checkbox.scss
+++ b/src/form/input/checkbox/_checkbox.scss
@@ -59,7 +59,7 @@
       background-color: $black;
       border-color: $black;
 
-      .check-icon {
+      svg {
         display: block;
       }
     }
@@ -108,7 +108,7 @@
 
   box-sizing: border-box;
 
-  .check-icon {
+  svg {
     display: none;
   }
 }

--- a/src/form/input/file/FileInput.tsx
+++ b/src/form/input/file/FileInput.tsx
@@ -1,0 +1,68 @@
+import "./_file-input.scss";
+
+import React from "react";
+import classNames from "classnames";
+
+import Spinner from "../../../spinner/Spinner";
+
+export interface FileInputProps {
+  testid?: string;
+  htmlFor: string;
+  name: string;
+  children: React.ReactNode;
+  onChange: React.ReactEventHandler<HTMLInputElement>;
+  isDisabled?: boolean;
+  isPending?: boolean;
+  customClassName?: string;
+  customLabelClassName?: string;
+  acceptedFileTypes?: string;
+  labelRef?: React.RefObject<HTMLLabelElement>;
+}
+
+function FileInput({
+  onChange,
+  children,
+  testid,
+  name,
+  htmlFor,
+  acceptedFileTypes = "image/png, image/jpeg, .pdf",
+  customClassName,
+  customLabelClassName,
+  isPending,
+  isDisabled,
+  labelRef
+}: FileInputProps) {
+  const containerClassName = classNames("file-input-container", customClassName);
+  const isInputDisabled = isPending || isDisabled;
+  const labelClassName = classNames("file-input-label", customLabelClassName, {
+    disabled: isInputDisabled
+  });
+
+  return (
+    <div className={containerClassName}>
+      <input
+        data-testid={testid}
+        type={"file"}
+        value={""}
+        name={name}
+        className={"file-input"}
+        onChange={onChange}
+        id={htmlFor}
+        disabled={isInputDisabled}
+        accept={acceptedFileTypes}
+      />
+
+      <label
+        ref={labelRef}
+        htmlFor={htmlFor}
+        className={labelClassName}
+        data-testid={`${testid}.label`}>
+        {children}
+
+        {isPending && <Spinner customClassName={"button-spinner"} />}
+      </label>
+    </div>
+  );
+}
+
+export default FileInput;

--- a/src/form/input/file/_file-input.scss
+++ b/src/form/input/file/_file-input.scss
@@ -1,0 +1,42 @@
+@import "../../../ui/reference/colors";
+@import "../../../ui/reference/measurement";
+
+.file-input {
+  position: absolute;
+  z-index: -1;
+
+  width: 0.1px;
+  height: 0.1px;
+
+  overflow: hidden;
+
+  opacity: 0;
+
+  &:focus + .file-input-label {
+    box-shadow: $default-box-shadow;
+  }
+
+  & + .file-input-label.disabled {
+    background-color: $light-grey;
+    
+    cursor: not-allowed;
+  }
+}
+
+.file-input-label {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  padding: 15px;
+
+  background-color: white;
+  border: 1px solid $light-grey;
+  border-radius: $small-radius-size;
+
+  cursor: pointer;
+
+  &.button {
+    min-width: 172px;
+  }
+}

--- a/src/form/input/radio/Radio.tsx
+++ b/src/form/input/radio/Radio.tsx
@@ -4,7 +4,7 @@ import React from "react";
 import classNames from "classnames";
 
 export interface RadioInputItem<Id = string> {
-  testid: string;
+  testid?: string;
   id: Id;
   content: React.ReactNode;
   inputProps: {

--- a/src/form/input/radio/_radio.scss
+++ b/src/form/input/radio/_radio.scss
@@ -5,7 +5,8 @@
 .radio-input-label {
   position: relative;
 
-  display: block;
+  display: grid;
+  grid-template-columns: 20px 1fr;
 
   margin-bottom: 10px;
   padding-left: 28px;
@@ -65,9 +66,9 @@
 }
 
 .radio-input-icon {
-  position: absolute;
-  top: 0;
-  left: 0;
+  position: relative;
+
+  display: block;
 
   width: 20px;
   height: 20px;

--- a/src/form/input/radio/group/RadioGroup.tsx
+++ b/src/form/input/radio/group/RadioGroup.tsx
@@ -6,7 +6,7 @@ import classNames from "classnames";
 import RadioInput, {RadioInputItem, RadioInputProps} from "../Radio";
 
 interface RadioGroupProps {
-  testid: string;
+  testid?: string;
   items: RadioInputItem[];
   selectedItem: null | RadioInputItem;
   onSelect: RadioInputProps["onSelect"];

--- a/src/form/input/radio/group/RadioGroup.tsx
+++ b/src/form/input/radio/group/RadioGroup.tsx
@@ -5,7 +5,7 @@ import classNames from "classnames";
 
 import RadioInput, {RadioInputItem, RadioInputProps} from "../Radio";
 
-interface RadioGroupProps {
+export interface RadioGroupProps {
   testid?: string;
   items: RadioInputItem[];
   selectedItem: null | RadioInputItem;

--- a/src/form/input/typeahead/TypeaheadInput.tsx
+++ b/src/form/input/typeahead/TypeaheadInput.tsx
@@ -1,0 +1,88 @@
+import React, {useEffect} from "react";
+import classNames from "classnames";
+
+import Input from "../Input";
+import useDebounce from "../../../core/utils/hooks/debounce";
+
+export interface TypeaheadInputProps {
+  testid?: string;
+  customClassName?: string;
+  id?: string;
+  name: string;
+  isDisabled?: boolean;
+  value?: string;
+  placeholder: string;
+  queryChangeDebounceTimeout?: number;
+  onQueryChange: (value: string) => void;
+  onFocus?: React.ReactEventHandler<HTMLInputElement>;
+  onBlur?: React.ReactEventHandler<HTMLInputElement>;
+  onKeyDown?: React.KeyboardEventHandler<HTMLInputElement>;
+  leftIcon?: React.ReactNode;
+  rightIcon?: React.ReactNode;
+  role?: string;
+  children?: React.ReactNode;
+  inputContainerRef?: React.RefObject<HTMLDivElement>;
+  shouldResetValue?: boolean;
+}
+
+const DEFAULT_DEBOUNCE_TIMEOUT = 250;
+
+function TypeaheadInput(props: TypeaheadInputProps) {
+  const {
+    testid,
+    placeholder,
+    name,
+    customClassName,
+    onFocus,
+    onBlur,
+    id,
+    role,
+    onKeyDown,
+    onQueryChange,
+    isDisabled = false,
+    leftIcon,
+    rightIcon,
+    value = "",
+    queryChangeDebounceTimeout = DEFAULT_DEBOUNCE_TIMEOUT,
+    inputContainerRef,
+    shouldResetValue
+  } = props;
+
+  const [inputValue, setInputValue] = useDebounce(
+    onQueryChange,
+    value,
+    queryChangeDebounceTimeout
+  );
+
+  useEffect(() => {
+    if (shouldResetValue) {
+      setInputValue("");
+    }
+  }, [shouldResetValue, setInputValue]);
+
+  return (
+    <Input
+      inputContainerRef={inputContainerRef}
+      customClassName={classNames("typeahead-input", customClassName)}
+      id={id}
+      testid={testid}
+      name={name}
+      placeholder={placeholder}
+      onChange={handleInputChange}
+      onFocus={onFocus}
+      onBlur={onBlur}
+      onKeyDown={onKeyDown}
+      value={inputValue}
+      isDisabled={isDisabled}
+      leftIcon={leftIcon}
+      rightIcon={rightIcon}
+      role={role}
+    />
+  );
+
+  function handleInputChange(event: React.SyntheticEvent<HTMLInputElement>) {
+    setInputValue(event.currentTarget.value);
+  }
+}
+
+export default TypeaheadInput;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,16 +1,18 @@
-import FormField from "./form/field/FormField";
-import Input from "./form/input/Input";
-import FileInput from "./form/input/file/FileInput";
-import CheckboxInput from "./form/input/checkbox/Checkbox";
-import RadioInput from "./form/input/radio/Radio";
-import RadioGroup from "./form/input/radio/group/RadioGroup";
-import TypeaheadInput from "./form/input/typeahead/TypeaheadInput";
-import TypeaheadSelect from "./select/typeahead/TypeaheadSelect";
-import Dropdown from "./dropdown/Dropdown";
-import List from "./list/List";
-import Button from "./button/Button";
-import FileUploadButton from "./button/file-upload/FileUploadButton";
-import Spinner from "./spinner/Spinner";
+import FormField, {FormFieldProps} from "./form/field/FormField";
+import Input, {InputProps} from "./form/input/Input";
+import FileInput, {FileInputProps} from "./form/input/file/FileInput";
+import CheckboxInput, {CheckboxInputProps} from "./form/input/checkbox/Checkbox";
+import RadioInput, {RadioInputProps} from "./form/input/radio/Radio";
+import RadioGroup, {RadioGroupProps} from "./form/input/radio/group/RadioGroup";
+import TypeaheadInput, {TypeaheadInputProps} from "./form/input/typeahead/TypeaheadInput";
+import TypeaheadSelect, {TypeaheadSelectProps} from "./select/typeahead/TypeaheadSelect";
+import Dropdown, {DropdownProps} from "./dropdown/Dropdown";
+import List, {ListProps} from "./list/List";
+import Button, {ButtonProps} from "./button/Button";
+import FileUploadButton, {
+  FileUploadButtonProps
+} from "./button/file-upload/FileUploadButton";
+import Spinner, {SpinnerProps} from "./spinner/Spinner";
 
 export {
   FormField,
@@ -25,5 +27,18 @@ export {
   List,
   Button,
   FileUploadButton,
-  Spinner
+  Spinner,
+  FormFieldProps,
+  InputProps,
+  FileInputProps,
+  CheckboxInputProps,
+  RadioInputProps,
+  RadioGroupProps,
+  TypeaheadInputProps,
+  TypeaheadSelectProps,
+  DropdownProps,
+  ListProps,
+  ButtonProps,
+  FileUploadButtonProps,
+  SpinnerProps
 };

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,8 @@ import Input from "./form/input/Input";
 import CheckboxInput from "./form/input/checkbox/Checkbox";
 import RadioInput from "./form/input/radio/Radio";
 import RadioGroup from "./form/input/radio/group/RadioGroup";
+import TypeaheadInput from "./form/input/typeahead/TypeaheadInput";
+import TypeaheadSelect from "./select/typeahead/TypeaheadSelect";
 import Dropdown from "./dropdown/Dropdown";
 import List from "./list/List";
 import Button from "./button/Button";
@@ -14,6 +16,8 @@ export {
   CheckboxInput,
   RadioInput,
   RadioGroup,
+  TypeaheadInput,
+  TypeaheadSelect,
   Dropdown,
   List,
   Button,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import FormField from "./form/field/FormField";
 import Input from "./form/input/Input";
+import FileInput from "./form/input/file/FileInput";
 import CheckboxInput from "./form/input/checkbox/Checkbox";
 import RadioInput from "./form/input/radio/Radio";
 import RadioGroup from "./form/input/radio/group/RadioGroup";
@@ -8,11 +9,13 @@ import TypeaheadSelect from "./select/typeahead/TypeaheadSelect";
 import Dropdown from "./dropdown/Dropdown";
 import List from "./list/List";
 import Button from "./button/Button";
+import FileUploadButton from "./button/file-upload/FileUploadButton";
 import Spinner from "./spinner/Spinner";
 
 export {
-  Input,
   FormField,
+  Input,
+  FileInput,
   CheckboxInput,
   RadioInput,
   RadioGroup,
@@ -21,5 +24,6 @@ export {
   Dropdown,
   List,
   Button,
+  FileUploadButton,
   Spinner
 };

--- a/src/list/List.tsx
+++ b/src/list/List.tsx
@@ -2,11 +2,11 @@ import "./_list.scss";
 
 import React, {Fragment} from "react";
 import classNames from "classnames";
-import {Button} from "..";
+import Button from "../button/Button";
 import Spinner from "../spinner/Spinner";
 
 interface ListProps<Item = any> {
-  testid: string;
+  testid?: string;
   customClassName?: string;
   items: Item;
   isPending?: boolean;

--- a/src/list/List.tsx
+++ b/src/list/List.tsx
@@ -5,7 +5,7 @@ import classNames from "classnames";
 import Button from "../button/Button";
 import Spinner from "../spinner/Spinner";
 
-interface ListProps<Item = any> {
+export interface ListProps<Item = any> {
   testid?: string;
   customClassName?: string;
   items: Item;

--- a/src/list/List.tsx
+++ b/src/list/List.tsx
@@ -8,7 +8,7 @@ import Spinner from "../spinner/Spinner";
 export interface ListProps<Item = any> {
   testid?: string;
   customClassName?: string;
-  items: Item;
+  items: Item[];
   isPending?: boolean;
   children: (item: Item, testid: string, index?: number) => JSX.Element;
   listItemKeyGenerator?: (item: Item, testid: string) => string;

--- a/src/select/typeahead/TypeaheadSelect.tsx
+++ b/src/select/typeahead/TypeaheadSelect.tsx
@@ -1,0 +1,189 @@
+import CaretDownIcon from "../../ui/icons/caret-down.svg";
+
+import "./_typeahead-select.scss";
+
+import React, {useState, useEffect, useRef} from "react";
+import classNames from "classnames";
+
+import {DropdownOption} from "../../dropdown/list/item/DropdownListItem";
+import TypeaheadInput, {
+  TypeaheadInputProps
+} from "../../form/input/typeahead/TypeaheadInput";
+import {mapDropdownOptionsToTagShapes} from "../../tag/util/tagUtils";
+import Tag, {TagShape} from "../../tag/Tag";
+import Dropdown from "../../dropdown/Dropdown";
+import {filterOptionsByKeyword} from "./util/typeaheadSelectUtils";
+import {filterOutItemsByKey} from "../../core/utils/arrayUtils";
+import Spinner from "../../spinner/Spinner";
+
+interface TypeaheadSelectProps {
+  testid?: string;
+  selectedOptions: DropdownOption[];
+  dropdownOptions: DropdownOption[];
+  onSelect: (option: DropdownOption) => void;
+  typeaheadProps: Omit<TypeaheadInputProps, "onQueryChange" | "testid" | "value">;
+  onTagRemove?: (option: DropdownOption) => void;
+  onKeywordChange?: (value: string) => void;
+  selectedOptionLimit?: number;
+  customClassName?: string;
+  shouldDisplaySelectedOptions?: boolean;
+  shouldFilterOptionsByKeyword?: boolean;
+  isDisabled?: boolean;
+  shouldShowEmptyOptions?: boolean;
+  canOpenDropdownMenu?: boolean;
+  areOptionsFetching?: boolean;
+}
+
+function TypeaheadSelect({
+  testid,
+  dropdownOptions,
+  selectedOptions,
+  typeaheadProps,
+  onTagRemove,
+  onKeywordChange,
+  onSelect,
+  customClassName,
+  selectedOptionLimit,
+  shouldDisplaySelectedOptions = true,
+  shouldFilterOptionsByKeyword = true,
+  isDisabled,
+  shouldShowEmptyOptions = true,
+  canOpenDropdownMenu = true,
+  areOptionsFetching
+}: TypeaheadSelectProps) {
+  const [isMenuOpen, setMenuVisibility] = useState(false);
+  const [computedDropdownOptions, setComputedDropdownOptions] = useState(dropdownOptions);
+  const [shouldResetTypeaheadValue, setShouldResetTypeaheadValue] = useState(false);
+  const [shouldFocusOnInput, setShouldFocusOnInput] = useState(false);
+  const typeaheadSelectClassName = classNames(
+    "typeahead-select-dropdown",
+    customClassName
+  );
+  const tags = mapDropdownOptionsToTagShapes(selectedOptions);
+  const shouldDisplayOnlyTags = Boolean(
+    selectedOptionLimit && selectedOptions.length >= selectedOptionLimit
+  );
+  const canSelectMultiple = !selectedOptionLimit || selectedOptionLimit > 1;
+  const shouldCloseOnSelect =
+    !canSelectMultiple ||
+    Boolean(selectedOptionLimit && selectedOptions.length >= selectedOptionLimit - 1);
+  const typeaheadClassName = classNames("typeahead-select-header", {
+    "is-dropdown-menu-open": isMenuOpen,
+    "can-select-multiple": canSelectMultiple
+  });
+  const typeaheadInputRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    setComputedDropdownOptions(dropdownOptions);
+  }, [dropdownOptions]);
+
+  useEffect(() => {
+    let timeoutId: any;
+
+    if (shouldFocusOnInput) {
+      timeoutId = setTimeout(() => {
+        if (typeaheadInputRef.current) {
+          typeaheadInputRef.current.focus();
+          setShouldFocusOnInput(false);
+        }
+      });
+    }
+
+    return () => {
+      clearTimeout(timeoutId);
+    };
+  }, [shouldFocusOnInput]);
+
+  const dropdownHeader = (
+    <div className={"typeahead-select-header-container"}>
+      {shouldDisplaySelectedOptions && Boolean(tags.length) && (
+        <div className={"typeahead-select-header-tags-container"}>
+          {tags.map((tag, index) => (
+            <Tag
+              key={tag.id}
+              testid={`${testid}.tag-${index}`}
+              onRemove={handleRemove}
+              customClassName={"typeahead-select-tag"}
+              tag={tag}
+            />
+          ))}
+        </div>
+      )}
+
+      {!shouldDisplayOnlyTags && (
+        <TypeaheadInput
+          testid={`${testid}.search`}
+          customClassName={typeaheadClassName}
+          inputContainerRef={typeaheadInputRef}
+          id={typeaheadProps.id}
+          name={typeaheadProps.name}
+          placeholder={typeaheadProps.placeholder}
+          onQueryChange={handleKeywordChange}
+          shouldResetValue={shouldResetTypeaheadValue}
+          rightIcon={
+            areOptionsFetching ? (
+              <Spinner spinnerColor={"#EBEBEB"} backgroundColor={"white"} />
+            ) : (
+              <CaretDownIcon aria-hidden={true} />
+            )
+          }
+          onFocus={openDropdownMenu}
+        />
+      )}
+    </div>
+  );
+
+  return (
+    <Dropdown
+      customClassName={typeaheadSelectClassName}
+      headerWithoutButton={dropdownHeader}
+      role={"listbox"}
+      options={filterOutItemsByKey(computedDropdownOptions, "id", selectedOptions)}
+      onSelect={handleSelect}
+      selectedOption={null}
+      isMenuOpenHook={[isMenuOpen, setMenuVisibility]}
+      hasDeselectOption={false}
+      shouldCloseOnSelect={shouldCloseOnSelect}
+      shouldJumpToQuery={false}
+      isDisabled={isDisabled}
+      areOptionsFetching={areOptionsFetching}
+      shouldShowEmptyOptions={shouldShowEmptyOptions}
+      canOpenDropdownMenu={canOpenDropdownMenu}
+    />
+  );
+
+  function openDropdownMenu() {
+    setMenuVisibility(true);
+  }
+
+  function handleSelect(option: DropdownOption | null) {
+    if (!shouldDisplayOnlyTags) {
+      onSelect(option!);
+      setShouldResetTypeaheadValue(true);
+      setComputedDropdownOptions(dropdownOptions);
+    }
+  }
+
+  function handleRemove(tag: TagShape<DropdownOption>) {
+    if (onTagRemove) {
+      onTagRemove(tag.context!);
+      setShouldFocusOnInput(true);
+    }
+  }
+
+  function handleKeywordChange(value: string) {
+    if (shouldFilterOptionsByKeyword) {
+      setComputedDropdownOptions(filterOptionsByKeyword(dropdownOptions, value));
+    }
+
+    if (onKeywordChange) {
+      onKeywordChange(value);
+    }
+
+    if (shouldResetTypeaheadValue && value === "") {
+      setShouldResetTypeaheadValue(false);
+    }
+  }
+}
+
+export default TypeaheadSelect;

--- a/src/select/typeahead/TypeaheadSelect.tsx
+++ b/src/select/typeahead/TypeaheadSelect.tsx
@@ -16,7 +16,7 @@ import {filterOptionsByKeyword} from "./util/typeaheadSelectUtils";
 import {filterOutItemsByKey} from "../../core/utils/arrayUtils";
 import Spinner from "../../spinner/Spinner";
 
-interface TypeaheadSelectProps {
+export interface TypeaheadSelectProps {
   testid?: string;
   selectedOptions: DropdownOption[];
   dropdownOptions: DropdownOption[];

--- a/src/select/typeahead/_typeahead-select.scss
+++ b/src/select/typeahead/_typeahead-select.scss
@@ -1,0 +1,76 @@
+@import "../../ui/reference/colors";
+@import "../../ui/reference/measurement";
+
+.typeahead-select-container {
+  .typeahead-select-dropdown .dropdown-header-button {
+    height: auto;
+
+    border: none;
+    box-shadow: none;
+
+    text-align: left;
+  }
+}
+
+.typeahead-select-header-container {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-start;
+
+  border: 1px solid $light-grey;
+  border-radius: $small-radius-size;
+}
+
+.typeahead-select-header-tags-container {
+  display: flex;
+
+  padding: 15px;
+
+  .typeahead-select-tag:not(:last-of-type) {
+    margin-right: 5px;
+  }
+}
+
+.typeahead-select-header {
+  &.can-select-multiple {
+    .input {
+      height: auto;
+      min-height: 45px;
+
+      flex: 1;
+
+      border: none;
+
+      &:focus {
+        border: none;
+      }
+    }
+
+    .typeahead-select-tag {
+      margin-top: 8px;
+      margin-left: 10px;
+    }
+  }
+
+  &.is-dropdown-menu-open {
+    position: relative;
+    z-index: 2;
+
+    & + .dropdown-overlay {
+      z-index: 1;
+    }
+  }
+}
+
+.typeahead-select-dropdown.disabled {
+  .typeahead-select-tag-list-container {
+    width: 100%;
+  }
+}
+
+.typeahead-select-right-icon-container {
+  path {
+    fill: $grey;
+  }
+}

--- a/src/select/typeahead/util/typeaheadSelectUtils.ts
+++ b/src/select/typeahead/util/typeaheadSelectUtils.ts
@@ -1,0 +1,19 @@
+import {DropdownOption} from "../../../dropdown/list/item/DropdownListItem";
+
+function filterOptionsByKeyword(
+  options: DropdownOption[],
+  keyword: string
+): DropdownOption[] {
+  let filteredOptions = options;
+
+  if (keyword) {
+    filteredOptions = options.filter(
+      (option) =>
+        !option.title || option.title.toLowerCase().includes(keyword.toLowerCase())
+    );
+  }
+
+  return filteredOptions;
+}
+
+export {filterOptionsByKeyword};

--- a/src/spinner/Spinner.tsx
+++ b/src/spinner/Spinner.tsx
@@ -3,7 +3,7 @@ import "./_spinner.scss";
 import React from "react";
 import classNames from "classnames";
 
-interface SpinnerProps {
+export interface SpinnerProps {
   customClassName?: string;
   spinnerColor?: string;
   backgroundColor?: string;

--- a/src/tag/Tag.tsx
+++ b/src/tag/Tag.tsx
@@ -1,0 +1,43 @@
+import CloseIcon from "../ui/icons/close.svg";
+
+import "./_tag.scss";
+
+import React from "react";
+import classNames from "classnames";
+
+import Button from "../button/Button";
+
+export interface TagShape<Context = any> {
+  id: string;
+  content: React.ReactNode;
+  context?: Context;
+}
+
+interface TagProps {
+  testid?: string;
+  tag: TagShape;
+  customClassName?: string;
+  onRemove?: (tag: TagShape) => void;
+}
+
+function Tag({testid, tag, onRemove, customClassName}: TagProps) {
+  const containerClassName = classNames("tag-container", customClassName);
+
+  return (
+    <Button
+      testid={`${testid}.remove-button`}
+      customClassName={containerClassName}
+      onClick={handleRemove}
+      shouldStopPropagation={true}>
+      <div className={"tag-body"}>{tag.content}</div>
+
+      <CloseIcon aria-hidden={true} />
+    </Button>
+  );
+
+  function handleRemove() {
+    onRemove!(tag);
+  }
+}
+
+export default Tag;

--- a/src/tag/_tag.scss
+++ b/src/tag/_tag.scss
@@ -1,0 +1,52 @@
+@import "../ui/reference/colors";
+@import "../ui/reference/measurement";
+@import "../ui/reference/animation";
+@import "../ui/reference/util/truncate";
+
+.tag-container {
+  display: flex;
+  align-items: center;
+
+  width: auto;
+  min-width: 0;
+  height: 100%;
+
+  padding: 3px 10px;
+
+  color: $black;
+
+  background-color: $light-grey;
+  border-radius: $small-radius-size;
+
+  &.button {
+    border: none;
+    border-radius: $small-radius-size;
+  }
+
+  svg {
+    width: 16px;
+    height: 16px;
+    flex: 0 0 16px;
+
+    margin-left: 10px;
+
+    background-color: transparent;
+    border: none;
+
+    path {
+      transition: stroke $animation-duration $animation-function;
+    }
+
+    &:hover {
+      path {
+        stroke: $black;
+      }
+    }
+  }
+}
+
+.tag-body {
+  @include truncate-line(calc(100% - 16px));
+
+  overflow: hidden;
+}

--- a/src/tag/util/tagUtils.ts
+++ b/src/tag/util/tagUtils.ts
@@ -1,0 +1,16 @@
+import {DropdownOption} from "./../../dropdown/list/item/DropdownListItem";
+import {TagShape} from "../Tag";
+
+function mapDropdownOptionToTagShape(option: DropdownOption): TagShape<DropdownOption> {
+  return {
+    id: option.id,
+    content: option.title,
+    context: option
+  };
+}
+
+function mapDropdownOptionsToTagShapes(options: DropdownOption[]) {
+  return options.map(mapDropdownOptionToTagShape);
+}
+
+export {mapDropdownOptionsToTagShapes};

--- a/src/ui/icons/close.svg
+++ b/src/ui/icons/close.svg
@@ -1,0 +1,4 @@
+<svg viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M4 12L12 4" stroke="#C7C7C7" stroke-width="1.5"/>
+<path d="M12 12L4 4" stroke="#C7C7C7" stroke-width="1.5"/>
+</svg>

--- a/stories/0-Form.stories.tsx
+++ b/stories/0-Form.stories.tsx
@@ -71,7 +71,6 @@ storiesOf("Form", module)
               onSelect={() => setState({...state, rememberMe: !state.rememberMe})}
               isSelected={state.rememberMe}
               item={{
-                testid: "rememberMe",
                 id: "rememberMe",
                 content: "Remember Me",
                 inputProps: {
@@ -88,7 +87,6 @@ storiesOf("Form", module)
               }
               isSelected={state.termsAndConditions}
               item={{
-                testid: "termsAndConditions",
                 id: "termsAndConditions",
                 content: "Terms and Conditions",
                 inputProps: {
@@ -104,7 +102,6 @@ storiesOf("Form", module)
               isSelected={state.privacyPolicy}
               isDisabled={true}
               item={{
-                testid: "privacyPolicy",
                 id: "privacyPolicy",
                 content: "Privacy Policy",
                 inputProps: {
@@ -194,7 +191,6 @@ storiesOf("Form", module)
           <Fragment>
             <FormField label={"Partially Disabled"}>
               <RadioGroup
-                testid="rg-test"
                 items={state.firstInput.choices}
                 selectedItem={state.firstInput.selectedItem}
                 onSelect={(name, item) =>
@@ -208,7 +204,6 @@ storiesOf("Form", module)
 
             <FormField label={"Fully Disabled"}>
               <RadioGroup
-                testid="rg-test-second"
                 items={state.secondInput.choices}
                 selectedItem={state.secondInput.selectedItem}
                 isDisabled={true}

--- a/stories/1-Dropdown.stories.tsx
+++ b/stories/1-Dropdown.stories.tsx
@@ -31,7 +31,6 @@ storiesOf("Dropdown", module).add("Dropdown States", () => {
           <FormField label={"Your Language"}>
             <Dropdown
               role={"listbox"}
-              testid={"dd-test"}
               options={state.options}
               placeholder={"Select Language"}
               onSelect={(option) => setState({...state, selectedOption: option})}
@@ -42,7 +41,6 @@ storiesOf("Dropdown", module).add("Dropdown States", () => {
           <FormField label={"Your Language"} errorMessages={["Please select a language"]}>
             <Dropdown
               role={"listbox"}
-              testid={"dd-test"}
               options={state.options}
               placeholder={"Select Language"}
               onSelect={(option) => setState({...state, selectedOption: option})}
@@ -54,7 +52,6 @@ storiesOf("Dropdown", module).add("Dropdown States", () => {
           <FormField label={"Your Language"}>
             <Dropdown
               role={"listbox"}
-              testid={"dd-test"}
               options={state.options}
               placeholder={"Select Language"}
               onSelect={(option) => setState({...state, selectedOption: option})}
@@ -66,7 +63,6 @@ storiesOf("Dropdown", module).add("Dropdown States", () => {
           <FormField label={"Your Language"}>
             <Dropdown
               role={"listbox"}
-              testid={"dd-test"}
               options={state.options}
               placeholder={"Select Language"}
               onSelect={(option) => setState({...state, selectedOption: option})}

--- a/stories/2-List.stories.tsx
+++ b/stories/2-List.stories.tsx
@@ -68,9 +68,7 @@ function UserListItem({user}) {
 storiesOf("List", module)
   .add("Has Items", () => (
     <Fragment>
-      <List testid={"users-list"} items={users}>
-        {(item) => <UserListItem user={item} />}
-      </List>
+      <List items={users}>{(item) => <UserListItem user={item} />}</List>
 
       {style}
     </Fragment>
@@ -78,7 +76,6 @@ storiesOf("List", module)
   .add("Has Placeholder", () => (
     <Fragment>
       <List
-        testid={"users-list"}
         items={emptyUsers}
         isPending={true}
         placeholders={renderPlaceolders()}
@@ -91,7 +88,7 @@ storiesOf("List", module)
   ))
   .add("Pending State", () => (
     <Fragment>
-      <List testid={"users-list"} isPending={true} items={emptyUsers}>
+      <List isPending={true} items={emptyUsers}>
         {(item) => <UserListItem user={item} />}
       </List>
     </Fragment>
@@ -99,7 +96,6 @@ storiesOf("List", module)
   .add("Empty State", () => (
     <Fragment>
       <List
-        testid={"users-list"}
         items={emptyUsers}
         emptyStateMessage={"Sorry, there are no users"}
         emptyStateButtonText={"Create User"}

--- a/stories/3-Button.stories.tsx
+++ b/stories/3-Button.stories.tsx
@@ -6,7 +6,7 @@ import Button from "../src/button/Button";
 storiesOf("Button", module)
   .add("Button Sizes", () => (
     <Fragment>
-      <Button type={"button"} testid={"test-button"} onClick={(e) => alert("Thank You!")}>
+      <Button type={"button"} onClick={(e) => alert("Thank You!")}>
         {"Click Me"}
       </Button>
 
@@ -15,7 +15,6 @@ storiesOf("Button", module)
       <Button
         customClassName={"size-small"}
         type={"button"}
-        testid={"test-button"}
         onClick={(e) => alert("Thank You!")}>
         {"Click Me"}
       </Button>
@@ -23,7 +22,13 @@ storiesOf("Button", module)
   ))
   .add("Button States", () => (
     <Fragment>
-      <Button type={"button"} testid={"test-button"} onClick={(e) => alert("Thank You!")}>
+      <Button type={"button"} onClick={(e) => alert("Thank You!")}>
+        {"Click Me"}
+      </Button>
+
+      <br />
+
+      <Button type={"button"} onClick={(e) => alert("Thank You!")} isDisabled={true}>
         {"Click Me"}
       </Button>
 
@@ -31,17 +36,6 @@ storiesOf("Button", module)
 
       <Button
         type={"button"}
-        testid={"test-button"}
-        onClick={(e) => alert("Thank You!")}
-        isDisabled={true}>
-        {"Click Me"}
-      </Button>
-
-      <br />
-
-      <Button
-        type={"button"}
-        testid={"test-button"}
         onClick={(e) => alert("Thank You!")}
         shouldDisplaySpinner={true}>
         {"Click Me"}
@@ -52,7 +46,6 @@ storiesOf("Button", module)
       <Button
         customClassName={"size-small"}
         type={"button"}
-        testid={"test-button"}
         onClick={(e) => alert("Thank You!")}>
         {"Click Me"}
       </Button>
@@ -62,7 +55,6 @@ storiesOf("Button", module)
       <Button
         customClassName={"size-small"}
         type={"button"}
-        testid={"test-button"}
         isDisabled={true}
         onClick={(e) => alert("Thank You!")}>
         {"Click Me"}
@@ -73,7 +65,6 @@ storiesOf("Button", module)
       <Button
         customClassName={"size-small"}
         type={"button"}
-        testid={"test-button"}
         shouldDisplaySpinner={true}
         onClick={(e) => alert("Thank You!")}>
         {"Click Me"}

--- a/stories/3-Button.stories.tsx
+++ b/stories/3-Button.stories.tsx
@@ -2,6 +2,7 @@ import React, {Fragment} from "react";
 import {storiesOf} from "@storybook/react";
 
 import Button from "../src/button/Button";
+import FileUploadButton from "../src/button/file-upload/FileUploadButton";
 
 storiesOf("Button", module)
   .add("Button Sizes", () => (
@@ -69,5 +70,25 @@ storiesOf("Button", module)
         onClick={(e) => alert("Thank You!")}>
         {"Click Me"}
       </Button>
+
+      <br />
+
+      <FileUploadButton
+        onFileSelect={(files) => console.log(files)}
+        fileInputProps={{name: "photos", htmlFor: "photos"}}>
+        {"Upload your photos"}
+      </FileUploadButton>
+
+      <br />
+
+      <FileUploadButton
+        onFileSelect={(files) => console.log(files)}
+        fileInputProps={{
+          name: "second-photos",
+          htmlFor: "second-photos",
+          isDisabled: true
+        }}>
+        {"Upload your photos"}
+      </FileUploadButton>
     </Fragment>
   ));

--- a/stories/5-Typeahead.stories.tsx
+++ b/stories/5-Typeahead.stories.tsx
@@ -1,0 +1,151 @@
+import React from "react";
+import {storiesOf} from "@storybook/react";
+
+import StateProvider from "./utils/StateProvider";
+
+import FormField from "../src/form/field/FormField";
+import TypeaheadSelect from "../src/select/typeahead/TypeaheadSelect";
+
+const simulateAPICall = (timeout = 1000) =>
+  new Promise((resolve) => setTimeout(resolve, timeout));
+
+storiesOf("Typeahead", module).add("Typeahead States", () => {
+  const initialState = {
+    options: [
+      {
+        id: "turkish",
+        title: "Turkish"
+      },
+      {
+        id: "english",
+        title: "English"
+      },
+      {
+        id: "spanish",
+        title: "Spanish"
+      }
+    ],
+    thirdOptions: [],
+    selectedOptions: [],
+    secondSelectedOptions: [],
+    thirdSelectedOptions: [],
+    areOptionsFetching: false
+  };
+
+  return (
+    <StateProvider initialState={initialState}>
+      {(state, setState) => (
+        <div style={{maxWidth: "350px"}}>
+          <FormField label={"Select Languages"}>
+            <TypeaheadSelect
+              dropdownOptions={initialState.options}
+              selectedOptions={state.selectedOptions}
+              onSelect={(option) =>
+                setState({...state, selectedOptions: [...state.selectedOptions, option]})
+              }
+              onTagRemove={handleRemoveTag(state, setState)}
+              typeaheadProps={{
+                placeholder: "Select Languages",
+                name: "language"
+              }}
+            />
+          </FormField>
+
+          <FormField label={"Select Languages (Max selectable 2)"}>
+            <TypeaheadSelect
+              selectedOptionLimit={2}
+              dropdownOptions={initialState.options}
+              selectedOptions={state.secondSelectedOptions}
+              onSelect={(option) =>
+                setState({
+                  ...state,
+                  secondSelectedOptions: [...state.secondSelectedOptions, option]
+                })
+              }
+              onTagRemove={handleRemoveTag(state, setState, "secondSelectedOptions")}
+              typeaheadProps={{
+                placeholder: "Select Languages",
+                name: "language"
+              }}
+            />
+          </FormField>
+
+          <FormField label={"Select Languages (Max selectable 2)"}>
+            <TypeaheadSelect
+              selectedOptionLimit={2}
+              isDisabled={true}
+              dropdownOptions={initialState.options}
+              selectedOptions={state.secondSelectedOptions}
+              onSelect={(option) =>
+                setState({
+                  ...state,
+                  secondSelectedOptions: [...state.secondSelectedOptions, option]
+                })
+              }
+              onTagRemove={handleRemoveTag(state, setState)}
+              typeaheadProps={{
+                placeholder: "Select Languages",
+                name: "language"
+              }}
+            />
+          </FormField>
+
+          <FormField label={"Select Languages (API Fetch Simulation)"}>
+            <TypeaheadSelect
+              shouldFilterOptionsByKeyword={false}
+              areOptionsFetching={state.areOptionsFetching}
+              dropdownOptions={state.thirdOptions}
+              selectedOptions={state.thirdSelectedOptions}
+              onSelect={(option) =>
+                setState({
+                  ...state,
+                  thirdSelectedOptions: [...state.thirdSelectedOptions, option]
+                })
+              }
+              onKeywordChange={handleKeywordChange(state, setState)}
+              onTagRemove={handleRemoveTag(state, setState, "thirdSelectedOptions")}
+              typeaheadProps={{
+                placeholder: "Select Languages",
+                name: "language-test"
+              }}
+            />
+          </FormField>
+        </div>
+      )}
+    </StateProvider>
+  );
+
+  function handleRemoveTag(state, setState, optionsArrayName = "selectedOptions") {
+    return (tag) =>
+      setState({
+        ...state,
+        [optionsArrayName]: state[optionsArrayName].filter(
+          (options) => options.id !== tag.id
+        )
+      });
+  }
+
+  function handleKeywordChange(state, setState) {
+    return async (keyword) => {
+      if (keyword) {
+        setState({
+          ...state,
+          areOptionsFetching: true
+        });
+
+        await simulateAPICall();
+
+        setState({
+          ...state,
+          areOptionsFetching: false,
+          thirdOptions: [
+            {
+              id: keyword,
+              title: keyword
+            }
+          ]
+        });
+      }
+    };
+  }
+});


### PR DESCRIPTION
### Description
- TypeaheadSelect, TypeaheadInput and Tag components are done 🎉 
- Added Typeahead related hooks and utilities
- Style improvements on Input component
- Made `testid` optional

**Added basic implementation examples of Typeahead, more will be added. [Check it out](https://react-ui-toolkit.muco.now.sh/?path=/story/typeahead--typeahead-states)**