### PR TITLE
fix: Make TypeaheadInput Value Controlled

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hipo/react-ui-toolkit",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "React based UI toolkit.",
   "main": "dist/index.js",
   "scripts": {

--- a/src/form/input/typeahead/TypeaheadInput.tsx
+++ b/src/form/input/typeahead/TypeaheadInput.tsx
@@ -60,6 +60,12 @@ function TypeaheadInput(props: TypeaheadInputProps) {
     }
   }, [shouldResetValue, setInputValue]);
 
+  useEffect(() => {
+    if (value) {
+      setInputValue(value);
+    }
+  }, [value, setInputValue]);
+
   return (
     <Input
       inputContainerRef={inputContainerRef}

--- a/src/select/typeahead/TypeaheadSelect.tsx
+++ b/src/select/typeahead/TypeaheadSelect.tsx
@@ -21,7 +21,7 @@ export interface TypeaheadSelectProps {
   selectedOptions: DropdownOption[];
   dropdownOptions: DropdownOption[];
   onSelect: (option: DropdownOption) => void;
-  typeaheadProps: Omit<TypeaheadInputProps, "onQueryChange" | "testid" | "value">;
+  typeaheadProps: Omit<TypeaheadInputProps, "onQueryChange" | "testid">;
   onTagRemove?: (option: DropdownOption) => void;
   onKeywordChange?: (value: string) => void;
   selectedOptionLimit?: number;
@@ -118,6 +118,7 @@ function TypeaheadSelect({
           id={typeaheadProps.id}
           name={typeaheadProps.name}
           placeholder={typeaheadProps.placeholder}
+          value={typeaheadProps.value}
           onQueryChange={handleKeywordChange}
           shouldResetValue={shouldResetTypeaheadValue}
           rightIcon={


### PR DESCRIPTION
### Description
- To control the value of `TypeaheadInput`'s value we needed to enable controlled value passing 
