### PR TITLE
fix(dropdown): Improvements on styles and handle menu visibility via CSS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@hipo/react-ui-toolkit",
-  "version": "0.2.3",
+  "version": "0.2.6",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/core/utils/domUtils.ts
+++ b/src/core/utils/domUtils.ts
@@ -1,9 +1,8 @@
 function computeScrollAmountToMakeChildVisible(parent: HTMLElement, child: HTMLElement) {
-  let visibilityBoundary = 0;
-  let scrollSize = 0;
-
   const {clientHeight: parentHeight, scrollTop: parentScrollTop} = parent;
   const {clientHeight: childHeight, offsetTop: childOffsetTop} = child;
+  let visibilityBoundary = 0;
+  let scrollSize = 0;
 
   visibilityBoundary = parentHeight - (childOffsetTop - parentScrollTop);
 

--- a/src/dropdown/Dropdown.tsx
+++ b/src/dropdown/Dropdown.tsx
@@ -1,8 +1,6 @@
 /* eslint-disable max-lines */
 import CaretDownIcon from "../ui/icons/caret-down.svg";
 
-import "./_dropdown.scss";
-
 import React, {Fragment, useState, useRef, useEffect} from "react";
 import classNames from "classnames";
 
@@ -27,6 +25,8 @@ import {
 import Spinner from "../spinner/Spinner";
 import {SINGLE_ALPHANUMERIC_CHARACTER_REGEX} from "../core/utils/stringConstants";
 import useOnClickOutside from "../core/utils/hooks/onClickOutside";
+
+import "./_dropdown.scss";
 
 export type MenuVisibilityChangeHandlerTypeArgument = "open" | "closed";
 

--- a/src/dropdown/Dropdown.tsx
+++ b/src/dropdown/Dropdown.tsx
@@ -201,26 +201,25 @@ function Dropdown<OptionIdShape extends string>({
       onKeyDown={handleKeyDown}>
       {dropdownHeader}
 
-      {shouldShowMenu && (
-        <DropdownList
-          testid={testid}
-          customClassName={position}
-          role={role}
-          options={computedOptions}
-          selectedOption={selectedOption}
-          focusedOption={computedOptions[focusedOptionIndex]}
-          onSelect={handleOptionSelect}
-          onFocus={handleOptionFocus}
-          // Pass mouseDown and mouseUp handlers to catch clicks within an option element and prevent blur
-          onMouseDown={handleMouseDown}
-          onMouseUp={handleMouseUp}
-          ariaLabelledBy={`${testid}.header-button`}
-          ariaHidden={!isMenuOpen}
-          isMultiSelect={isMultiSelect}
-          canSelectAlreadySelected={canSelectAlreadySelected}
-          noOptionsMessage={noOptionsMessage}
-        />
-      )}
+      <DropdownList
+        testid={testid}
+        isVisible={shouldShowMenu}
+        customClassName={position}
+        role={role}
+        options={computedOptions}
+        selectedOption={selectedOption}
+        focusedOption={computedOptions[focusedOptionIndex]}
+        onSelect={handleOptionSelect}
+        onFocus={handleOptionFocus}
+        // Pass mouseDown and mouseUp handlers to catch clicks within an option element and prevent blur
+        onMouseDown={handleMouseDown}
+        onMouseUp={handleMouseUp}
+        ariaLabelledBy={`${testid}.header-button`}
+        ariaHidden={!isMenuOpen}
+        isMultiSelect={isMultiSelect}
+        canSelectAlreadySelected={canSelectAlreadySelected}
+        noOptionsMessage={noOptionsMessage}
+      />
     </div>
   );
 
@@ -235,6 +234,10 @@ function Dropdown<OptionIdShape extends string>({
         // @ts-ignore
         onSelect(option, event);
       }
+
+      setFocusedOptionIndex(
+        generateInitialFocusedDropdownOptionIndex(position, computedOptions, option)
+      );
     }
 
     if (shouldCloseOnSelect) {
@@ -254,18 +257,23 @@ function Dropdown<OptionIdShape extends string>({
   }
 
   function toggleDropdown() {
-    setMenuVisibility(!isMenuOpen);
+    if (isMenuOpen) {
+      closeDropdown();
+    } else {
+      setMenuVisibility(true);
+    }
   }
 
   function handleDropdownFocus() {
-    if (!isMouseDown && canOpenDropdownMenu) {
+    // `document.hidden` is used on dropdown focus and blur handlers to handle changes on screen visibility correctly
+    if (!document.hidden && !isMouseDown && canOpenDropdownMenu) {
       setMenuVisibility(true);
     }
   }
 
   function handleBlur() {
     // Prevent blur on option clicks
-    if (!isMouseDown && isMenuOpen) {
+    if (!document.hidden && !isMouseDown && isMenuOpen) {
       toggleDropdown();
     }
 

--- a/src/dropdown/Dropdown.tsx
+++ b/src/dropdown/Dropdown.tsx
@@ -26,6 +26,7 @@ import Spinner from "../spinner/Spinner";
 import {SINGLE_ALPHANUMERIC_CHARACTER_REGEX} from "../core/utils/stringConstants";
 import useOnClickOutside from "../core/utils/hooks/onClickOutside";
 
+// This import is moved to come after other imports so that we can avoid nesting to override some of the styles that comes from other components, such as `Button`.
 import "./_dropdown.scss";
 
 export type MenuVisibilityChangeHandlerTypeArgument = "open" | "closed";

--- a/src/dropdown/_dropdown.scss
+++ b/src/dropdown/_dropdown.scss
@@ -7,23 +7,6 @@ $dropdown-header-horizontal-padding: 8px;
 .dropdown-container {
   position: relative;
 
-  .dropdown-header-button {
-    width: 100%;
-    height: 40px;
-
-    background-color: white;
-    border: 1px solid var(--default-border-color);
-    border-radius: var(--small-border-radius);
-
-    &:focus {
-      outline: none;
-    }
-  }
-
-  .dropdown-header-button-text {
-    color: var(--dropdown-text-color);
-  }
-
   &.has-header-box-shadow {
     .dropdown-header-button {
       box-shadow: var(--default-box-shadow);
@@ -51,40 +34,18 @@ $dropdown-header-horizontal-padding: 8px;
     }
   }
 
-  .dropdown-list {
-    position: absolute;
-    z-index: 1;
-
-    max-height: 320px;
-
-    overflow: auto;
-
-    &.top {
-      top: 0;
-
-      transform: translateY(-100%);
-    }
-
-    &.bottom {
-      bottom: -15px;
-
-      transform: translateY(100%);
-    }
-
-    &.left {
-      top: 0;
-      left: 0;
-
-      transform: translate(-100%, -50%);
-    }
-
-    &.right {
-      top: 0;
-      right: 0;
-
-      transform: translate(100%, -50%);
-    }
+  &:focus {
+    outline: none;
   }
+}
+
+.dropdown-header-button {
+  width: 100%;
+  height: var(--dropdown-header-button-height);
+
+  background-color: white;
+  border: var(--dropdown-header-button-border-width) solid var(--default-border-color);
+  border-radius: var(--small-border-radius);
 
   &:focus {
     outline: none;
@@ -95,6 +56,8 @@ $dropdown-header-horizontal-padding: 8px;
   @include truncate-line(calc(100% - #{$dropdown-header-horizontal-padding}));
 
   flex: 1;
+
+  color: var(--dropdown-text-color);
 
   text-align: left;
 }

--- a/src/dropdown/list/DropdownList.tsx
+++ b/src/dropdown/list/DropdownList.tsx
@@ -1,6 +1,6 @@
 import "./_dropdown-list.scss";
 
-import React, {useRef, useEffect} from "react";
+import React, {useRef, useLayoutEffect} from "react";
 import classNames from "classnames";
 
 import DropdownListItem, {
@@ -11,12 +11,13 @@ import DropdownListItem, {
 import {computeScrollAmountToMakeChildVisible} from "../../core/utils/domUtils";
 
 interface DropdownListProps<OptionIdShape extends string> {
-  testid?: string;
+  isVisible: boolean;
   options: DropdownOption<OptionIdShape>[];
   selectedOption: DropdownSelectedOption<OptionIdShape>;
   focusedOption: DropdownSelectedOption<OptionIdShape>;
   onSelect: DropdownOptionSelectHandler<OptionIdShape>;
   onFocus: DropdownOptionSelectHandler<OptionIdShape>;
+  testid?: string;
   onMouseDown?: React.ReactEventHandler<HTMLLIElement>;
   onMouseUp?: React.ReactEventHandler<HTMLLIElement>;
   onKeyDown?: DropdownOptionSelectHandler<OptionIdShape>;
@@ -32,6 +33,7 @@ interface DropdownListProps<OptionIdShape extends string> {
 
 function DropdownList<OptionIdShape extends string>({
   testid,
+  isVisible,
   options,
   customClassName,
   role,
@@ -49,35 +51,19 @@ function DropdownList<OptionIdShape extends string>({
   noOptionsMessage
 }: DropdownListProps<OptionIdShape>) {
   const listRef = useRef<HTMLUListElement>(null);
-  const containerClassName = classNames("dropdown-list", customClassName);
+  const listItemRef = useRef<HTMLLIElement>(null);
+  const containerClassName = classNames("dropdown-list", customClassName, {
+    "dropdown-list__is-visible": isVisible
+  });
 
-  useEffect(() => {
-    if (listRef.current) {
-      const focusedOptionElement =
-        focusedOption && document.getElementById(focusedOption.id);
-
-      if (focusedOptionElement) {
-        listRef.current.scrollTop += computeScrollAmountToMakeChildVisible(
-          listRef.current,
-          focusedOptionElement
-        );
-      }
+  useLayoutEffect(() => {
+    if (isVisible && listRef.current && listItemRef.current) {
+      listRef.current.scrollTop += computeScrollAmountToMakeChildVisible(
+        listRef.current,
+        listItemRef.current
+      );
     }
-  }, [focusedOption]);
-
-  useEffect(() => {
-    if (listRef.current) {
-      const selectedOptionElement =
-        selectedOption && document.getElementById(selectedOption.id);
-
-      if (selectedOptionElement) {
-        listRef.current.scrollTop += computeScrollAmountToMakeChildVisible(
-          listRef.current,
-          selectedOptionElement
-        );
-      }
-    }
-  }, [selectedOption]);
+  }, [isVisible, focusedOption]);
 
   return (
     <ul
@@ -102,6 +88,7 @@ function DropdownList<OptionIdShape extends string>({
     return (
       <DropdownListItem
         key={option.id}
+        focusedItemRef={option.id === focusedOption?.id ? listItemRef : undefined}
         testid={`${testid}.item-${index}`}
         option={option}
         selectedOption={selectedOption}

--- a/src/dropdown/list/DropdownList.tsx
+++ b/src/dropdown/list/DropdownList.tsx
@@ -53,7 +53,7 @@ function DropdownList<OptionIdShape extends string>({
   const listRef = useRef<HTMLUListElement>(null);
   const listItemRef = useRef<HTMLLIElement>(null);
   const containerClassName = classNames("dropdown-list", customClassName, {
-    "dropdown-list__is-visible": isVisible
+    "dropdown-list--is-visible": isVisible
   });
 
   useLayoutEffect(() => {

--- a/src/dropdown/list/_dropdown-list.scss
+++ b/src/dropdown/list/_dropdown-list.scss
@@ -2,9 +2,14 @@
 @import "../../ui/reference/_measurement.scss";
 
 .dropdown-list {
+  position: absolute;
+  z-index: 1;
+
   width: 100%;
+  max-height: 320px;
 
   box-sizing: border-box;
+  overflow: auto;
 
   padding: 0;
 
@@ -13,6 +18,32 @@
   border-radius: var(--small-radius-size);
   visibility: hidden;
   opacity: 0;
+
+  &.top {
+    top: 0;
+
+    transform: translateY(-100%);
+  }
+
+  &.bottom {
+    bottom: -15px;
+
+    transform: translateY(100%);
+  }
+
+  &.left {
+    top: 0;
+    left: 0;
+
+    transform: translate(-100%, -50%);
+  }
+
+  &.right {
+    top: 0;
+    right: 0;
+
+    transform: translate(100%, -50%);
+  }
 }
 
 .dropdown-list__is-visible {

--- a/src/dropdown/list/_dropdown-list.scss
+++ b/src/dropdown/list/_dropdown-list.scss
@@ -11,6 +11,13 @@
   background-color: white;
   border: 1px solid var(--default-border-color);
   border-radius: var(--small-radius-size);
+  visibility: hidden;
+  opacity: 0;
+}
+
+.dropdown-list__is-visible {
+  visibility: visible;
+  opacity: 1;
 }
 
 .dropdown-empty-message {

--- a/src/dropdown/list/_dropdown-list.scss
+++ b/src/dropdown/list/_dropdown-list.scss
@@ -46,7 +46,7 @@
   }
 }
 
-.dropdown-list__is-visible {
+.dropdown-list--is-visible {
   visibility: visible;
   opacity: 1;
 }

--- a/src/dropdown/list/item/DropdownListItem.tsx
+++ b/src/dropdown/list/item/DropdownListItem.tsx
@@ -34,6 +34,7 @@ interface DropdownListItemProps<OptionIdShape = string> {
   onMouseDown?: React.ReactEventHandler<HTMLLIElement>;
   onMouseUp?: React.ReactEventHandler<HTMLLIElement>;
   canSelectAlreadySelected?: boolean;
+  focusedItemRef?: React.RefObject<HTMLLIElement>;
 }
 
 function DropdownListItem<OptionIdShape extends string>({
@@ -46,7 +47,8 @@ function DropdownListItem<OptionIdShape extends string>({
   onKeyDown,
   onMouseDown,
   onMouseUp,
-  canSelectAlreadySelected = false
+  canSelectAlreadySelected = false,
+  focusedItemRef
 }: DropdownListItemProps<OptionIdShape>) {
   const {id: optionId, customClassName, icon, title, subtitle, CustomContent} = option;
   const isSelected = Boolean(selectedOption && optionId === selectedOption.id);
@@ -59,6 +61,7 @@ function DropdownListItem<OptionIdShape extends string>({
 
   return (
     <li
+      ref={focusedItemRef}
       data-testid={testid}
       id={optionId}
       role={"option"}

--- a/src/ui/reference/_measurement.scss
+++ b/src/ui/reference/_measurement.scss
@@ -8,6 +8,10 @@
   // Input
   --input-height: 45px;
 
+  // Dropdown
+  --dropdown-header-button-height: 40px;
+  --dropdown-header-button-border-width: 1px;
+
   // Defaults
   --small-radius-size: 2px;
 }


### PR DESCRIPTION
### Description

- `document.hidden` is used on dropdown focus and blur handlers to handle changes on screen visibility correctly
- Instead of toggling the whole dropdown menu from DOM, we now use CSS to handle its visibility
- Effect that listens `selectOption` to focus on it is removed and now we only use `focusedOption` to handle scroll computations
- Direct DOM access to the focused list item element is removed to use React Ref API.
- Nesting of `dropdown-header-button` CSS block is removed