### PR TITLE
fix: Export `main.css` instead of inline styles

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,11 +7,10 @@ Hipo's React based UI Toolkit / [Demo](https://react-ui-toolkit.now.sh/)
 After installing the `@hipo/react-ui-toolkit` package you can start with simple example
 
 ```javascript
-import FormField from "@hipo/react-ui-toolkit/dist/Input";
-import Input from "@hipo/react-ui-toolkit/dist/Input";
+import {FormField, Input} from "@hipo/react-ui-toolkit/dist/Input";
 
-// or you can directly import the index
-// import {FormField, Input} from "@hipo/react-ui-toolkit"
+// This is required to gather the initial styles of the components
+import "@hipo/react-ui-toolkit/dist/main.css";
 
 function LoginForm() {
   return (
@@ -23,6 +22,8 @@ function LoginForm() {
       <FormField label="Password">
         <Input name="password" type="password" />
       </FormField>
+
+      <Button>Login</Button>
     </div>
   );
 }
@@ -53,9 +54,3 @@ Or you can run `npm run storybook` to see the components live. Storybook has own
 ESLint and Prettier will handle the linting task. You can set a watcher for `npm run prettier:fix` command in your IDE otherwise you need to run prettier manually or right before the production build it'll automatically runs.
 
 The ruleset can be found in [@hipo/eslint-config-base](https://github.com/Hipo/eslint-config-hipo-base), [@hipo/eslint-config-react](https://github.com/Hipo/eslint-config-hipo-base)
-
-### TODO
-
-- [ ] Add tests
-- [ ] Add source info of components to Storybook
-- [x] Components should have basic CSS styles

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@hipo/react-ui-toolkit",
-  "version": "0.2.6",
+  "version": "0.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hipo/react-ui-toolkit",
-  "version": "0.2.7",
+  "version": "0.3.0",
   "description": "React based UI toolkit.",
   "main": "dist/index.js",
   "scripts": {

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -5,6 +5,8 @@ import postcss from "rollup-plugin-postcss";
 import stylelint from "rollup-plugin-stylelint";
 import reactSvg from "rollup-plugin-react-svg";
 
+const path = require("path");
+
 export default [
   {
     external: ["react", "classnames"],
@@ -38,7 +40,9 @@ export default [
       stylelint({
         ignoreFiles: ["**/*.ts", "**/*.js"]
       }),
-      postcss(),
+      postcss({
+        extract: path.resolve("dist/main.css")
+      }),
       typescript({
         rollupCommonJSResolveHack: true,
         exclude: "**/__tests__/**",

--- a/src/button/_button.scss
+++ b/src/button/_button.scss
@@ -1,6 +1,3 @@
-@import "../ui/reference/_measurement.scss";
-@import "../ui/reference/_colors.scss";
-
 .button {
   display: block;
 

--- a/src/dropdown/_dropdown.scss
+++ b/src/dropdown/_dropdown.scss
@@ -1,6 +1,4 @@
-@import "../ui/reference/_colors.scss";
-@import "../ui/reference/_measurement.scss";
-@import "../ui/reference/util/_truncate.scss";
+@import "../ui/reference/util/truncate";
 
 $dropdown-header-horizontal-padding: 8px;
 

--- a/src/dropdown/list/_dropdown-list.scss
+++ b/src/dropdown/list/_dropdown-list.scss
@@ -1,6 +1,3 @@
-@import "../../ui/reference/_colors.scss";
-@import "../../ui/reference/_measurement.scss";
-
 .dropdown-list {
   position: absolute;
   z-index: 1;

--- a/src/dropdown/list/item/_dropdown-list-item.scss
+++ b/src/dropdown/list/item/_dropdown-list-item.scss
@@ -1,5 +1,4 @@
 @import "../../../ui/reference/util/truncate";
-@import "../../../ui/reference/colors";
 @import "../../../ui/reference/animation";
 
 .dropdown-list-item {

--- a/src/form/field/_form-field.scss
+++ b/src/form/field/_form-field.scss
@@ -1,5 +1,3 @@
-@import "../../ui/reference/colors";
-
 .form-field {
   margin-bottom: 25px;
 

--- a/src/form/field/message-row/_form-field-message-row.scss
+++ b/src/form/field/message-row/_form-field-message-row.scss
@@ -1,5 +1,3 @@
-@import "../../../ui/reference/_colors.scss";
-
 .form-field-message-row {
   margin: 8px 0;
 

--- a/src/form/input/_input.scss
+++ b/src/form/input/_input.scss
@@ -1,6 +1,3 @@
-@import "../../ui/reference/_colors.scss";
-@import "../../ui/reference/_measurement.scss";
-
 .input-container {
   display: flex;
   align-items: center;

--- a/src/form/input/checkbox/_checkbox.scss
+++ b/src/form/input/checkbox/_checkbox.scss
@@ -1,6 +1,4 @@
-@import "../../../ui/reference/_colors.scss";
-@import "../../../ui/reference/_measurement.scss";
-@import "../../../ui/reference/_animation.scss";
+@import "../../../ui/reference/animation";
 
 .checkbox-input-label {
   position: relative;

--- a/src/form/input/file/_file-input.scss
+++ b/src/form/input/file/_file-input.scss
@@ -1,6 +1,3 @@
-@import "../../../ui/reference/colors";
-@import "../../../ui/reference/measurement";
-
 .file-input {
   position: absolute;
   z-index: -1;

--- a/src/form/input/radio/_radio.scss
+++ b/src/form/input/radio/_radio.scss
@@ -1,6 +1,4 @@
-@import "../../../ui/reference/_colors.scss";
-@import "../../../ui/reference/_measurement.scss";
-@import "../../../ui/reference/_animation.scss";
+@import "../../../ui/reference/animation";
 
 .radio-input-label {
   position: relative;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,6 @@
+import "./ui/reference/_colors.scss";
+import "./ui/reference/_measurement.scss";
+
 import FormField, {FormFieldProps} from "./form/field/FormField";
 import Input, {InputProps} from "./form/input/Input";
 import FileInput, {FileInputProps} from "./form/input/file/FileInput";

--- a/src/select/typeahead/_typeahead-select.scss
+++ b/src/select/typeahead/_typeahead-select.scss
@@ -1,6 +1,3 @@
-@import "../../ui/reference/colors";
-@import "../../ui/reference/measurement";
-
 .typeahead-select-container {
   .typeahead-select-dropdown .dropdown-header-button {
     height: auto;

--- a/src/tag/_tag.scss
+++ b/src/tag/_tag.scss
@@ -1,5 +1,3 @@
-@import "../ui/reference/colors";
-@import "../ui/reference/measurement";
 @import "../ui/reference/animation";
 @import "../ui/reference/util/truncate";
 


### PR DESCRIPTION
### Description
- With `0.3.0` we're requiring to import the `main.css` to use initial styles 
- Removed unused imports to reduce the bundle size

### Notes
Resolves https://github.com/Hipo/react-ui-toolkit/issues/30