### PR TITLE
fix(typeahead/select): Use `canOpenDropdownMenu`

### DIFF
--- a/src/select/typeahead/TypeaheadSelect.tsx
+++ b/src/select/typeahead/TypeaheadSelect.tsx
@@ -158,7 +158,9 @@ function TypeaheadSelect({
   }
 
   function handleTypeaheadInputFocus(event: React.SyntheticEvent<HTMLInputElement>) {
-    openDropdownMenu();
+    if (canOpenDropdownMenu) {
+      openDropdownMenu();
+    }
 
     if (typeaheadProps.onFocus) {
       typeaheadProps.onFocus(event);


### PR DESCRIPTION
### Description
- We've `canOpenDropdownMenu` prop to lock the menu but `TypeaheadSelect` doesn't uses this. So, I've added a tiny check to `handleTypeaheadInputFocus`