### PR TITLE
fix(typeahead-select): Improves the handling of controlled keyword state

### DIFF
--- a/src/form/input/typeahead/TypeaheadInput.tsx
+++ b/src/form/input/typeahead/TypeaheadInput.tsx
@@ -5,15 +5,16 @@ import Input from "../Input";
 import useDebounce from "../../../core/utils/hooks/debounce";
 
 export interface TypeaheadInputProps {
+  onQueryChange: (value: string) => void;
+  value?: string;
   testid?: string;
   customClassName?: string;
   id?: string;
   name: string;
   isDisabled?: boolean;
-  value?: string;
+  initialValue?: string;
   placeholder: string;
   queryChangeDebounceTimeout?: number;
-  onQueryChange: (value: string) => void;
   onFocus?: React.ReactEventHandler<HTMLInputElement>;
   onBlur?: React.ReactEventHandler<HTMLInputElement>;
   onKeyDown?: React.KeyboardEventHandler<HTMLInputElement>;
@@ -22,7 +23,6 @@ export interface TypeaheadInputProps {
   role?: string;
   children?: React.ReactNode;
   inputContainerRef?: React.RefObject<HTMLDivElement>;
-  shouldResetValue?: boolean;
 }
 
 const DEFAULT_DEBOUNCE_TIMEOUT = 250;
@@ -42,26 +42,20 @@ function TypeaheadInput(props: TypeaheadInputProps) {
     isDisabled = false,
     leftIcon,
     rightIcon,
-    value = "",
+    initialValue = "",
+    value,
     queryChangeDebounceTimeout = DEFAULT_DEBOUNCE_TIMEOUT,
-    inputContainerRef,
-    shouldResetValue
+    inputContainerRef
   } = props;
 
   const [inputValue, setInputValue] = useDebounce(
     onQueryChange,
-    value,
+    initialValue,
     queryChangeDebounceTimeout
   );
 
   useEffect(() => {
-    if (shouldResetValue) {
-      setInputValue("");
-    }
-  }, [shouldResetValue, setInputValue]);
-
-  useEffect(() => {
-    if (value) {
+    if (typeof value === "string") {
       setInputValue(value);
     }
   }, [value, setInputValue]);

--- a/src/select/typeahead/TypeaheadSelect.tsx
+++ b/src/select/typeahead/TypeaheadSelect.tsx
@@ -19,13 +19,15 @@ import List from "../../list/List";
 import ListItem from "../../list/item/ListItem";
 
 export interface TypeaheadSelectProps {
-  testid?: string;
   selectedOptions: DropdownOption[];
   dropdownOptions: DropdownOption[];
   onSelect: (option: DropdownOption) => void;
-  typeaheadProps: Omit<TypeaheadInputProps, "onQueryChange" | "testid">;
-  onTagRemove?: (option: DropdownOption) => void;
+  testid?: string;
+  typeaheadProps: Pick<TypeaheadInputProps, "id" | "placeholder" | "name" | "onFocus">;
   onKeywordChange?: (value: string) => void;
+  initialKeyword?: string;
+  controlledKeyword?: string;
+  onTagRemove?: (option: DropdownOption) => void;
   selectedOptionLimit?: number;
   customClassName?: string;
   shouldDisplaySelectedOptions?: boolean;
@@ -51,13 +53,16 @@ function TypeaheadSelect({
   isDisabled,
   shouldShowEmptyOptions = true,
   canOpenDropdownMenu = true,
-  areOptionsFetching
+  areOptionsFetching,
+  initialKeyword = "",
+  controlledKeyword
 }: TypeaheadSelectProps) {
   const typeaheadInputRef = useRef<HTMLDivElement | null>(null);
   const [isMenuOpen, setMenuVisibility] = useState(false);
   const [computedDropdownOptions, setComputedDropdownOptions] = useState(dropdownOptions);
-  const [shouldResetTypeaheadValue, setShouldResetTypeaheadValue] = useState(false);
   const [shouldFocusOnInput, setShouldFocusOnInput] = useState(false);
+  const [keyword, setKeyword] = useState(initialKeyword);
+  const inputValue = typeof controlledKeyword === "string" ? controlledKeyword : keyword;
 
   const tags = mapDropdownOptionsToTagShapes(selectedOptions);
   const shouldDisplayOnlyTags = Boolean(
@@ -124,9 +129,8 @@ function TypeaheadSelect({
           id={typeaheadProps.id}
           name={typeaheadProps.name}
           placeholder={typeaheadProps.placeholder}
-          value={typeaheadProps.value}
+          value={inputValue}
           onQueryChange={handleKeywordChange}
-          shouldResetValue={shouldResetTypeaheadValue}
           rightIcon={
             areOptionsFetching ? (
               <Spinner spinnerColor={"#EBEBEB"} backgroundColor={"white"} />
@@ -178,6 +182,7 @@ function TypeaheadSelect({
     if (!shouldDisplayOnlyTags) {
       onSelect(option!);
       setComputedDropdownOptions(dropdownOptions);
+      setKeyword("");
     }
   }
 
@@ -197,8 +202,8 @@ function TypeaheadSelect({
       onKeywordChange(value);
     }
 
-    if (shouldResetTypeaheadValue && value === "") {
-      setShouldResetTypeaheadValue(false);
+    if (typeof controlledKeyword === "undefined") {
+      setKeyword(value);
     }
   }
 }

--- a/stories/5-Typeahead.stories.tsx
+++ b/stories/5-Typeahead.stories.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import {storiesOf} from "@storybook/react";
 
 import StateProvider from "./utils/StateProvider";
+import StoryFragment from "./utils/StoryFragment";
 
 import FormField from "../src/form/field/FormField";
 import TypeaheadSelect from "../src/select/typeahead/TypeaheadSelect";
@@ -29,90 +30,139 @@ storiesOf("Typeahead", module).add("Typeahead States", () => {
     selectedOptions: [],
     secondSelectedOptions: [],
     thirdSelectedOptions: [],
-    areOptionsFetching: false
+    areOptionsFetching: false,
+    keyword: ""
   };
 
   return (
-    <StateProvider initialState={initialState}>
-      {(state, setState) => (
-        <div style={{maxWidth: "350px"}}>
-          <FormField label={"Select Languages"}>
-            <TypeaheadSelect
-              dropdownOptions={initialState.options}
-              selectedOptions={state.selectedOptions}
-              onSelect={(option) =>
-                setState({...state, selectedOptions: [...state.selectedOptions, option]})
-              }
-              onTagRemove={handleRemoveTag(state, setState)}
-              typeaheadProps={{
-                placeholder: "Select Languages",
-                name: "language"
-              }}
-            />
-          </FormField>
+    <StoryFragment>
+      <div style={{maxWidth: "350px"}}>
+        <StateProvider initialState={initialState}>
+          {(state, setState) => (
+            <FormField label={"Select Languages"}>
+              <TypeaheadSelect
+                dropdownOptions={initialState.options}
+                selectedOptions={state.selectedOptions}
+                onSelect={(option) =>
+                  setState({
+                    ...state,
+                    selectedOptions: [...state.selectedOptions, option]
+                  })
+                }
+                onTagRemove={handleRemoveTag(state, setState)}
+                typeaheadProps={{
+                  placeholder: "Select Languages",
+                  name: "language"
+                }}
+              />
+            </FormField>
+          )}
+        </StateProvider>
 
-          <FormField label={"Select Languages (Max selectable 2)"}>
-            <TypeaheadSelect
-              selectedOptionLimit={2}
-              dropdownOptions={initialState.options}
-              selectedOptions={state.secondSelectedOptions}
-              onSelect={(option) =>
-                setState({
-                  ...state,
-                  secondSelectedOptions: [...state.secondSelectedOptions, option]
-                })
-              }
-              onTagRemove={handleRemoveTag(state, setState, "secondSelectedOptions")}
-              typeaheadProps={{
-                placeholder: "Select Languages",
-                name: "language"
-              }}
-            />
-          </FormField>
+        <StateProvider initialState={initialState}>
+          {(state, setState) => (
+            <FormField label={"Select Languages (Max selectable 2)"}>
+              <TypeaheadSelect
+                selectedOptionLimit={2}
+                dropdownOptions={initialState.options}
+                selectedOptions={state.secondSelectedOptions}
+                onSelect={(option) =>
+                  setState({
+                    ...state,
+                    secondSelectedOptions: [...state.secondSelectedOptions, option]
+                  })
+                }
+                onTagRemove={handleRemoveTag(state, setState, "secondSelectedOptions")}
+                typeaheadProps={{
+                  placeholder: "Select Languages",
+                  name: "language"
+                }}
+              />
+            </FormField>
+          )}
+        </StateProvider>
 
-          <FormField label={"Select Languages (Max selectable 2) - Disabled"}>
-            <TypeaheadSelect
-              selectedOptionLimit={2}
-              isDisabled={true}
-              dropdownOptions={initialState.options}
-              selectedOptions={state.secondSelectedOptions}
-              onSelect={(option) =>
-                setState({
-                  ...state,
-                  secondSelectedOptions: [...state.secondSelectedOptions, option]
-                })
-              }
-              onTagRemove={handleRemoveTag(state, setState)}
-              typeaheadProps={{
-                placeholder: "Select Languages",
-                name: "language"
-              }}
-            />
-          </FormField>
+        <StateProvider initialState={initialState}>
+          {(state, setState) => (
+            <FormField label={"Select Languages (Max selectable 2) - Disabled"}>
+              <TypeaheadSelect
+                selectedOptionLimit={2}
+                isDisabled={true}
+                dropdownOptions={initialState.options}
+                selectedOptions={state.secondSelectedOptions}
+                onSelect={(option) =>
+                  setState({
+                    ...state,
+                    secondSelectedOptions: [...state.secondSelectedOptions, option]
+                  })
+                }
+                onTagRemove={handleRemoveTag(state, setState)}
+                typeaheadProps={{
+                  placeholder: "Select Languages",
+                  name: "language"
+                }}
+              />
+            </FormField>
+          )}
+        </StateProvider>
 
-          <FormField label={"Select Languages (API Fetch Simulation)"}>
-            <TypeaheadSelect
-              shouldFilterOptionsByKeyword={false}
-              areOptionsFetching={state.areOptionsFetching}
-              dropdownOptions={state.thirdOptions}
-              selectedOptions={state.thirdSelectedOptions}
-              onSelect={(option) =>
-                setState({
-                  ...state,
-                  thirdSelectedOptions: [...state.thirdSelectedOptions, option]
-                })
-              }
-              onKeywordChange={handleKeywordChange(state, setState)}
-              onTagRemove={handleRemoveTag(state, setState, "thirdSelectedOptions")}
-              typeaheadProps={{
-                placeholder: "Select Languages",
-                name: "language-test"
-              }}
-            />
-          </FormField>
-        </div>
-      )}
-    </StateProvider>
+        <StateProvider initialState={initialState}>
+          {(state, setState) => (
+            <FormField
+              label={
+                "Select Languages (API Fetch Simulation) - with keyword by TypeaheadSelect"
+              }>
+              <TypeaheadSelect
+                shouldFilterOptionsByKeyword={false}
+                areOptionsFetching={state.areOptionsFetching}
+                dropdownOptions={state.thirdOptions}
+                selectedOptions={state.thirdSelectedOptions}
+                onSelect={(option) =>
+                  setState({
+                    ...state,
+                    thirdSelectedOptions: [...state.thirdSelectedOptions, option]
+                  })
+                }
+                onKeywordChange={handleKeywordChange(state, setState)}
+                onTagRemove={handleRemoveTag(state, setState, "thirdSelectedOptions")}
+                typeaheadProps={{
+                  placeholder: "Select Languages",
+                  name: "language-test"
+                }}
+              />
+            </FormField>
+          )}
+        </StateProvider>
+
+        <StateProvider initialState={initialState}>
+          {(state, setState) => (
+            <FormField
+              label={"Select Languages (API Fetch Simulation) - with keyword by parent"}>
+              <TypeaheadSelect
+                shouldFilterOptionsByKeyword={false}
+                areOptionsFetching={state.areOptionsFetching}
+                dropdownOptions={state.thirdOptions}
+                selectedOptions={state.thirdSelectedOptions}
+                onSelect={(option) =>
+                  setState({
+                    ...state,
+                    thirdSelectedOptions: [...state.thirdSelectedOptions, option],
+                    keyword: ""
+                  })
+                }
+                onKeywordChange={handleKeywordChange(state, setState)}
+                controlledKeyword={state.keyword}
+                onTagRemove={handleRemoveTag(state, setState, "thirdSelectedOptions")}
+                typeaheadProps={{
+                  placeholder: "Select Languages",
+                  name: "language-test"
+                }}
+              />
+            </FormField>
+          )}
+        </StateProvider>
+      </div>
+    </StoryFragment>
   );
 
   function handleRemoveTag(state, setState, optionsArrayName = "selectedOptions") {
@@ -128,15 +178,16 @@ storiesOf("Typeahead", module).add("Typeahead States", () => {
   function handleKeywordChange(state, setState) {
     return async (keyword) => {
       if (keyword) {
-        setState({
-          ...state,
-          areOptionsFetching: true
-        });
+        setState((prevState) => ({
+          ...prevState,
+          areOptionsFetching: true,
+          keyword
+        }));
 
         await simulateAPICall();
 
-        setState({
-          ...state,
+        setState((prevState) => ({
+          ...prevState,
           areOptionsFetching: false,
           thirdOptions: [
             {
@@ -144,7 +195,7 @@ storiesOf("Typeahead", module).add("Typeahead States", () => {
               title: keyword
             }
           ]
-        });
+        }));
       }
     };
   }


### PR DESCRIPTION
### Changes

**`TypeaheadInput` component**

- new `initialValue` prop added and it defaults to empty string.
- when `value` prop is present and it has a string value, this means that TypeaheadInput's value is held as a state in the parent and should be controlled by the parent as well. So whenever value changes and it has a string value then we update the TypeaheadInput's state. TypeaheadInput still controls its own state as it has to deal with debouncing.
- Removes `shouldResetValue` prop.


**`TypeaheadSelect` component**

- `typeaheadProps` prop is updated to have the following type: `Pick<TypeaheadInputProps, "id" | "placeholder" | "name" | "onFocus">`. Note how you cannot pass `value` under this object any longer.
- new `initialKeyword` prop added and it defaults to empty string.
- TypeaheadSelect now resets the input value by the default when an option is selected.
- new `controlledKeyword` prop is added. When this prop is present and it has a non-undefined value it means that the keyword is held as a state in the parent and therefore should be controlled by the parent. When this prop is present, `TypeaheadSelect` never updates its `keyword` state (a good example of inversion of control).

**Stories**

- Updated Typeahead stories so that each typeahead example holds its own state and not affected by the changes on other typeaheads within the page.
- Added an example story about how one can use `controlledKeyword`.