### PR TITLE
feat(dropdown): Add samples with icon/subtitle/context/menu

### DIFF
--- a/src/dropdown/list/item/DropdownListItem.tsx
+++ b/src/dropdown/list/item/DropdownListItem.tsx
@@ -53,7 +53,8 @@ function DropdownListItem<OptionIdShape extends string>({
 }: DropdownListItemProps<OptionIdShape>) {
   const {id: optionId, customClassName, icon, title, subtitle, CustomContent} = option;
   const isSelected = Boolean(selectedOption && optionId === selectedOption.id);
-  const canItemBeClicked = !option.isDisabled && (!isSelected || canSelectAlreadySelected);
+  const canItemBeClicked =
+    !option.isDisabled && (!isSelected || canSelectAlreadySelected);
   const containerClassName = classNames("dropdown-list-item", customClassName, {
     "dropdown-list-item--is-selected": isSelected,
     "dropdown-list-item--is-focused": Boolean(

--- a/src/dropdown/list/item/_dropdown-list-item.scss
+++ b/src/dropdown/list/item/_dropdown-list-item.scss
@@ -41,6 +41,9 @@
 }
 
 .dropdown-list-item__content {
+  display: flex;
+  align-items: center;
+
   min-width: 0;
 }
 
@@ -54,5 +57,8 @@
 .dropdown-list-item__subtitle {
   @include truncate-line();
 
-  margin-left: 5px;
+  margin-left: 8px;
+
+  font-size: 12px;
+  line-height: 18px;
 }

--- a/stories/1-Dropdown.stories.tsx
+++ b/stories/1-Dropdown.stories.tsx
@@ -1,35 +1,78 @@
-import React from "react";
+import React, {Fragment} from "react";
 import {storiesOf} from "@storybook/react";
 
 import Dropdown from "../src/dropdown/Dropdown";
 import StateProvider from "./utils/StateProvider";
 import FormField from "../src/form/field/FormField";
+import StoryFragment from "./utils/StoryFragment";
 
-storiesOf("Dropdown", module).add("Dropdown States", () => {
-  const initialState = {
-    options: [
-      {
-        id: "turkish",
-        title: "Turkish"
-      },
-      {
-        id: "english",
-        title: "English"
-      },
-      {
-        id: "spanish",
-        title: "Spanish"
-      },
-      {
-        id: "french",
-        title: "French - Disabled",
-        isDisabled: true
+const initialState = {
+  options: [
+    {
+      id: "turkish",
+      title: "Turkish"
+    },
+    {
+      id: "english",
+      title: "English"
+    },
+    {
+      id: "spanish",
+      title: "Spanish"
+    },
+    {
+      id: "french",
+      title: "French - Disabled",
+      isDisabled: true
+    }
+  ],
+  selectedOption: null
+};
+
+const initialStateWithSubtitle = {
+  options: [
+    {
+      id: "html",
+      title: "HTML",
+      subtitle: "HyperText Markup Language"
+    },
+    {
+      id: "css",
+      title: "CSS",
+      subtitle: "Cascading Style Sheets"
+    },
+    {
+      id: "js",
+      title: "JS",
+      subtitle: "JavaScript"
+    }
+  ],
+  selectedOption: null
+};
+
+const initialStateWithContext = {
+  options: [
+    {
+      id: "js",
+      title: "JavaScript",
+      context: {
+        icon: "https://img.icons8.com/dusk/48/000000/javascript-logo.png",
+        url: "https://developer.mozilla.org/en-US/docs/Learn/JavaScript"
       }
-    ],
-    selectedOption: null
-  };
+    },
+    {
+      id: "ts",
+      title: "TypeScript",
+      context: {
+        icon: "https://img.icons8.com/color/48/000000/typescript.png",
+        url: "https://www.typescriptlang.org/"
+      }
+    }
+  ]
+};
 
-  return (
+storiesOf("Dropdown", module)
+  .add("Dropdown States", () => (
     <StateProvider initialState={initialState}>
       {(state, setState) => (
         <div style={{maxWidth: "350px"}}>
@@ -55,17 +98,121 @@ storiesOf("Dropdown", module).add("Dropdown States", () => {
               hasError={true}
             />
           </FormField>
+        </div>
+      )}
+    </StateProvider>
+  ))
+  .add("Dropdown Menu", () => (
+    <StateProvider initialState={initialState}>
+      {(state, setState) => (
+        <StoryFragment>
+          <div style={{maxWidth: "350px"}}>
+            <FormField>
+              <Dropdown
+                role={"menu"}
+                options={state.options}
+                placeholder={"Select Language"}
+                onSelect={(option) => setState({...state, selectedOption: option})}
+                selectedOption={state.selectedOption}
+                hasDeselectOption={false}
+                header={
+                  <div>
+                    <span className={"circle"} />
+                    <span className={"dropdown-header"}>{"Language Menu"}</span>
+                    <style>
+                      {`
+                        .circle {
+                          height: 8px;
+                          width: 8px;
+                          background-color: blue;
+                          border-radius: 50%;
+                          display: inline-block;
+                        }
+                        
+                        .dropdown-header {
+                          color: black;
+                          margin-left: 16px;
+                        }
+                        `}
+                    </style>
+                  </div>
+                }
+              />
+            </FormField>
+          </div>
 
-          <FormField label={"Your Language - no options"}>
+          <span>{`Selected Language: ${
+            state.selectedOption ? state.selectedOption.title : "-"
+          }`}</span>
+        </StoryFragment>
+      )}
+    </StateProvider>
+  ))
+  .add("Dropdown Options With Subtitles", () => (
+    <StateProvider initialState={initialStateWithSubtitle}>
+      {(state, setState) => (
+        <div style={{maxWidth: "350px"}}>
+          <FormField label={"Web Courses"}>
             <Dropdown
               role={"listbox"}
-              options={[]}
+              options={state.options}
+              placeholder={"Select Language"}
+              onSelect={(option) => setState({...state, selectedOption: option})}
+              selectedOption={state.selectedOption}
+            />
+          </FormField>
+        </div>
+      )}
+    </StateProvider>
+  ))
+  .add("Dropdown With Customized Options", () => (
+    <StateProvider initialState={initialStateWithContext}>
+      {(state, setState) => (
+        <div style={{maxWidth: "350px"}}>
+          <FormField label={"Web Courses"}>
+            <Dropdown
+              role={"listbox"}
+              options={state.options}
               placeholder={"Select Language"}
               onSelect={(option) => setState({...state, selectedOption: option})}
               selectedOption={state.selectedOption}
             />
           </FormField>
 
+          {state.selectedOption && (
+            <Fragment>
+              <div
+                style={{
+                  width: "48px",
+                  height: "48px",
+                  backgroundImage: `url(${state.selectedOption.context.icon})`
+                }}
+              />
+
+              <a href={state.selectedOption.context.url}>{"Visit Website"}</a>
+            </Fragment>
+          )}
+        </div>
+      )}
+    </StateProvider>
+  ))
+  .add("No Options", () => (
+    <div style={{maxWidth: "350px"}}>
+      <FormField label={"Your Language - No Options"}>
+        <Dropdown
+          role={"listbox"}
+          options={[]}
+          placeholder={"Select Language"}
+          onSelect={(option) => console.log(option)}
+          selectedOption={initialState.selectedOption}
+        />
+      </FormField>
+    </div>
+  ))
+  .add("Pending Request", () => (
+    <StateProvider initialState={initialState}>
+      {(state, setState) => (
+        <div style={{maxWidth: "350px"}}>
           <FormField label={"Your Language"}>
             <Dropdown
               role={"listbox"}
@@ -76,19 +223,21 @@ storiesOf("Dropdown", module).add("Dropdown States", () => {
               areOptionsFetching={true}
             />
           </FormField>
-
-          <FormField label={"Your Language"}>
-            <Dropdown
-              role={"listbox"}
-              options={state.options}
-              placeholder={"Select Language"}
-              onSelect={(option) => setState({...state, selectedOption: option})}
-              selectedOption={state.selectedOption}
-              isDisabled={true}
-            />
-          </FormField>
         </div>
       )}
     </StateProvider>
-  );
-});
+  ))
+  .add("Disabled", () => (
+    <div style={{maxWidth: "350px"}}>
+      <FormField label={"Your Language"}>
+        <Dropdown
+          role={"listbox"}
+          options={initialState.options}
+          placeholder={"Select Language"}
+          onSelect={(option) => console.log(option)}
+          selectedOption={initialState.options[1]}
+          isDisabled={true}
+        />
+      </FormField>
+    </div>
+  ));

--- a/stories/1-Dropdown.stories.tsx
+++ b/stories/1-Dropdown.stories.tsx
@@ -5,77 +5,13 @@ import Dropdown from "../src/dropdown/Dropdown";
 import StateProvider from "./utils/StateProvider";
 import FormField from "../src/form/field/FormField";
 import StoryFragment from "./utils/StoryFragment";
-
-const initialState = {
-  options: [
-    {
-      id: "turkish",
-      title: "Turkish"
-    },
-    {
-      id: "english",
-      title: "English"
-    },
-    {
-      id: "spanish",
-      title: "Spanish"
-    },
-    {
-      id: "french",
-      title: "French - Disabled",
-      isDisabled: true
-    }
-  ],
-  selectedOption: null
-};
-
-const initialStateWithSubtitle = {
-  options: [
-    {
-      id: "html",
-      title: "HTML",
-      subtitle: "HyperText Markup Language"
-    },
-    {
-      id: "css",
-      title: "CSS",
-      subtitle: "Cascading Style Sheets"
-    },
-    {
-      id: "js",
-      title: "JS",
-      subtitle: "JavaScript"
-    }
-  ],
-  selectedOption: null
-};
-
-const initialStateWithContext = {
-  options: [
-    {
-      id: "js",
-      title: "JavaScript",
-      context: {
-        icon: "https://img.icons8.com/dusk/48/000000/javascript-logo.png",
-        url: "https://developer.mozilla.org/en-US/docs/Learn/JavaScript"
-      }
-    },
-    {
-      id: "ts",
-      title: "TypeScript",
-      context: {
-        icon: "https://img.icons8.com/color/48/000000/typescript.png",
-        url: "https://www.typescriptlang.org/"
-      }
-    }
-  ]
-};
+import {initialState} from "./utils/constants/dropdownStoryOptionConstants";
 
 storiesOf("Dropdown", module)
   .add("Dropdown States", () => (
-    <StateProvider initialState={initialState}>
+    <StateProvider initialState={initialState.basic}>
       {(state, setState) => (
-        <div style={{maxWidth: "350px"}}>
+        <div className={"dropdown-story-container"}>
           <FormField label={"Your Language"}>
             <Dropdown
               role={"listbox"}
@@ -103,10 +39,10 @@ storiesOf("Dropdown", module)
     </StateProvider>
   ))
   .add("Dropdown Menu", () => (
-    <StateProvider initialState={initialState}>
+    <StateProvider initialState={initialState.basic}>
       {(state, setState) => (
         <StoryFragment>
-          <div style={{maxWidth: "350px"}}>
+          <div className={"dropdown-story-container"}>
             <FormField>
               <Dropdown
                 role={"menu"}
@@ -119,22 +55,6 @@ storiesOf("Dropdown", module)
                   <div>
                     <span className={"circle"} />
                     <span className={"dropdown-header"}>{"Language Menu"}</span>
-                    <style>
-                      {`
-                        .circle {
-                          height: 8px;
-                          width: 8px;
-                          background-color: blue;
-                          border-radius: 50%;
-                          display: inline-block;
-                        }
-                        
-                        .dropdown-header {
-                          color: black;
-                          margin-left: 16px;
-                        }
-                        `}
-                    </style>
                   </div>
                 }
               />
@@ -149,9 +69,9 @@ storiesOf("Dropdown", module)
     </StateProvider>
   ))
   .add("Dropdown Options With Subtitles", () => (
-    <StateProvider initialState={initialStateWithSubtitle}>
+    <StateProvider initialState={initialState.withSubtitle}>
       {(state, setState) => (
-        <div style={{maxWidth: "350px"}}>
+        <div className={"dropdown-story-container"}>
           <FormField label={"Web Courses"}>
             <Dropdown
               role={"listbox"}
@@ -165,54 +85,71 @@ storiesOf("Dropdown", module)
       )}
     </StateProvider>
   ))
-  .add("Dropdown With Customized Options", () => (
-    <StateProvider initialState={initialStateWithContext}>
-      {(state, setState) => (
-        <div style={{maxWidth: "350px"}}>
-          <FormField label={"Web Courses"}>
-            <Dropdown
-              role={"listbox"}
-              options={state.options}
-              placeholder={"Select Language"}
-              onSelect={(option) => setState({...state, selectedOption: option})}
-              selectedOption={state.selectedOption}
-            />
-          </FormField>
-
-          {state.selectedOption && (
-            <Fragment>
-              <div
-                style={{
-                  width: "48px",
-                  height: "48px",
-                  backgroundImage: `url(${state.selectedOption.context.icon})`
-                }}
+  .add("Customized Dropdowns", () => (
+    <StoryFragment>
+      <StateProvider initialState={initialState.withContext}>
+        {(state, setState) => (
+          <div className={"dropdown-story-container"}>
+            <FormField label={"Using context to share more data with dropdown options"}>
+              <Dropdown
+                role={"listbox"}
+                options={state.options}
+                placeholder={"Select Language"}
+                onSelect={(option) => setState({...state, selectedOption: option})}
+                selectedOption={state.selectedOption}
               />
+            </FormField>
 
-              <a href={state.selectedOption.context.url}>{"Visit Website"}</a>
-            </Fragment>
-          )}
-        </div>
-      )}
-    </StateProvider>
+            {state.selectedOption && (
+              <Fragment>
+                <img
+                  className={"dropdown-context-icon"}
+                  src={state.selectedOption.context.icon}
+                />
+
+                <a href={state.selectedOption.context.url}>{"Visit Website"}</a>
+              </Fragment>
+            )}
+          </div>
+        )}
+      </StateProvider>
+
+      <br />
+
+      <StateProvider initialState={initialState.withCustomContent}>
+        {(state, setState) => (
+          <div className={"dropdown-story-container"}>
+            <FormField label={"Using CustomContent to display custom dropdown options"}>
+              <Dropdown
+                role={"listbox"}
+                options={state.options}
+                placeholder={"Select Coin"}
+                onSelect={(option) => setState({...state, selectedOption: option})}
+                selectedOption={state.selectedOption}
+              />
+            </FormField>
+          </div>
+        )}
+      </StateProvider>
+    </StoryFragment>
   ))
   .add("No Options", () => (
-    <div style={{maxWidth: "350px"}}>
+    <div className={"dropdown-story-container"}>
       <FormField label={"Your Language - No Options"}>
         <Dropdown
           role={"listbox"}
           options={[]}
           placeholder={"Select Language"}
           onSelect={(option) => console.log(option)}
-          selectedOption={initialState.selectedOption}
+          selectedOption={initialState.basic.selectedOption}
         />
       </FormField>
     </div>
   ))
   .add("Pending Request", () => (
-    <StateProvider initialState={initialState}>
+    <StateProvider initialState={initialState.basic}>
       {(state, setState) => (
-        <div style={{maxWidth: "350px"}}>
+        <div className={"dropdown-story-container"}>
           <FormField label={"Your Language"}>
             <Dropdown
               role={"listbox"}
@@ -228,14 +165,14 @@ storiesOf("Dropdown", module)
     </StateProvider>
   ))
   .add("Disabled", () => (
-    <div style={{maxWidth: "350px"}}>
+    <div className={"dropdown-story-container"}>
       <FormField label={"Your Language"}>
         <Dropdown
           role={"listbox"}
-          options={initialState.options}
+          options={initialState.basic.options}
           placeholder={"Select Language"}
           onSelect={(option) => console.log(option)}
-          selectedOption={initialState.options[1]}
+          selectedOption={initialState.basic.options[1]}
           isDisabled={true}
         />
       </FormField>

--- a/stories/utils/constants/_dropdown-story-option-constants.scss
+++ b/stories/utils/constants/_dropdown-story-option-constants.scss
@@ -1,0 +1,40 @@
+.dropdown-story-container {
+  max-width: 350px;
+}
+
+.dropdown-header {
+  margin-left: 16px;
+  
+  color: black;
+}
+
+.circle {
+  display: inline-block;
+
+  width: 8px;
+  height: 8px;
+
+  background-color: blue;
+  border-radius: 50%;
+}
+
+.coin-dropdown-option-custom-content {
+  display: grid;
+  grid-template-columns: 26px 52px 120px 34px;
+  gap: 18px;
+
+  span {
+    margin-top: 5px;
+  }
+
+  small {
+    margin-top: 7px;
+  }
+}
+
+.dropdown-context-icon {
+  width: 48px;
+  height: 48px;
+
+  margin-right: 16px;
+}

--- a/stories/utils/constants/dropdownStoryOptionConstants.tsx
+++ b/stories/utils/constants/dropdownStoryOptionConstants.tsx
@@ -1,0 +1,135 @@
+import "./_dropdown-story-option-constants.scss";
+
+import React from "react";
+
+function CoinDropdownOptionCustomContent({
+  id,
+  iconSrc,
+  price,
+  change
+}: {
+  id: string;
+  iconSrc: string;
+  price: string;
+  change: string;
+}) {
+  return (
+    <div className={"coin-dropdown-option-custom-content"}>
+      <img src={iconSrc} />
+      <small>{id}</small>
+      <span>{price}</span>
+      <span>{change}%</span>
+    </div>
+  );
+}
+
+const initialState = {
+  basic: {
+    options: [
+      {
+        id: "turkish",
+        title: "Turkish"
+      },
+      {
+        id: "english",
+        title: "English"
+      },
+      {
+        id: "spanish",
+        title: "Spanish"
+      },
+      {
+        id: "french",
+        title: "French - Disabled",
+        isDisabled: true
+      }
+    ],
+    selectedOption: null
+  },
+  withSubtitle: {
+    options: [
+      {
+        id: "html",
+        title: "HTML",
+        subtitle: "HyperText Markup Language"
+      },
+      {
+        id: "css",
+        title: "CSS",
+        subtitle: "Cascading Style Sheets"
+      },
+      {
+        id: "js",
+        title: "JS",
+        subtitle: "JavaScript"
+      }
+    ],
+    selectedOption: null
+  },
+  withContext: {
+    options: [
+      {
+        id: "js",
+        title: "JavaScript",
+        context: {
+          icon: "https://img.icons8.com/dusk/48/000000/javascript-logo.png",
+          url: "https://developer.mozilla.org/en-US/docs/Learn/JavaScript"
+        }
+      },
+      {
+        id: "ts",
+        title: "TypeScript",
+        context: {
+          icon: "https://img.icons8.com/color/48/000000/typescript.png",
+          url: "https://www.typescriptlang.org/"
+        }
+      }
+    ],
+    selectedOption: null
+  },
+  withCustomContent: {
+    options: [
+      {
+        id: "btc",
+        title: "Bitcoin",
+        CustomContent: (
+          <CoinDropdownOptionCustomContent
+            id={"BTC"}
+            iconSrc={"https://img.icons8.com/metro/26/000000/bitcoin.png"}
+            price={"$58,223"}
+            change={"12.4"}
+          />
+        )
+      },
+      {
+        id: "eth",
+        title: "Ethereum",
+        CustomContent: (
+          <CoinDropdownOptionCustomContent
+            id={"ETH"}
+            iconSrc={
+              "https://img.icons8.com/fluent-systems-filled/26/000000/ethereum.png"
+            }
+            price={"$18.064"}
+            change={"8.52"}
+          />
+        )
+      },
+      {
+        id: "ltc",
+        title: "Litecoin",
+        CustomContent: (
+          <CoinDropdownOptionCustomContent
+            id={"LTC"}
+            iconSrc={"https://img.icons8.com/ios-filled/26/000000/litecoin.png"}
+            price={"$224.498"}
+            change={"34.26"}
+          />
+        )
+      }
+    ],
+    selectedOption: null
+  }
+};
+
+export {initialState};


### PR DESCRIPTION
### Description
- Dropdown subtitle CSS class has `font-size` properties smaller than the title class.
- Dropdown samples have separated as `States`, `No Options`, `Pending Request`, `Disabled`.

### New Samples
- Dropdown Menu with icon
- Dropdown options with subtitle
- Dropdown with customized options

### Related Issue
- https://github.com/Hipo/react-ui-toolkit/issues/50