### PR TITLE
fix(file-input): Set file input container as relative positioned

### DIFF
--- a/src/form/input/file/_file-input.scss
+++ b/src/form/input/file/_file-input.scss
@@ -1,3 +1,7 @@
+.file-input__container {
+  position: relative;
+}
+
 .file-input {
   position: absolute;
   z-index: -1;


### PR DESCRIPTION
- Sets the file input container position as `relative` to prevent positioning related bugs (because `.file-input` child is `absolute` positioned)