### PR TITLE
build: Add GH workflows for automating npm publish and tagging on github

### DIFF
--- a/.github/workflows/new-version.yml
+++ b/.github/workflows/new-version.yml
@@ -1,0 +1,30 @@
+name: "New Version Actions"
+
+on:
+  push:
+    branches: # only trigger when a commit was pushed to master
+      - master
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 10
+      - run: npm install
+      - run: npm run build
+
+      - id: publish-to-npm
+        uses: JS-DevTools/npm-publish@v1
+        with:
+          token: ${{ secrets.NPM_TOKEN }} # This token should be added from repo settings
+
+      - id: create-gh-release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
+        with:
+          tag_name: ${{ steps.publish.outputs.version }}
+          release_name: ${{ steps.publish.outputs.version }}


### PR DESCRIPTION
I created a new npm account for GitHub actions: [hipo-web-bot](https://www.npmjs.com/~hipo-web-bot)

_~~I will add it's API key to the repo secrets, once it is added to the `@hipo` organization on npm~~_
`NPM_TOKEN` was added to the repo by @mucahit . This is ready to merge