### PR TITLE
fix(gh-actions): Fix `new-version` workflow step name typo

### DIFF
--- a/.github/workflows/new-version.yml
+++ b/.github/workflows/new-version.yml
@@ -26,5 +26,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
         with:
-          tag_name: ${{ steps.publish.outputs.version }}
-          release_name: ${{ steps.publish.outputs.version }}
+          tag_name: ${{ steps.publish-to-npm.outputs.version }}
+          release_name: ${{ steps.publish-to-npm.outputs.version }}


### PR DESCRIPTION
Use correct step name (id) in `create-gh-release` step for getting output version
