### PR TITLE
fix(core): Add `--isolatedModules` flag

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hipo/react-ui-toolkit",
-  "version": "1.0.0-alpha.3.0.0",
+  "version": "1.0.0-alpha.3.0.1",
   "description": "React based UI toolkit.",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "test": "jest",
     "prettier:fix": "./node_modules/.bin/prettier --config ./.prettierrc.js --write 'src/**/*.{ts,tsx}' 'stories/**/*.{ts,tsx}'",
     "storybook": "./node_modules/.bin/start-storybook -p 6006",
-    "storybook:build": "./node_modules/.bin/build-storybook"
+    "storybook:build": "./node_modules/.bin/build-storybook",
+    "type-check": "echo \"type-checking...\" && tsc --noEmit"
   },
   "jest": {
     "preset": "ts-jest",

--- a/src/core/utils/time/timeTypes.ts
+++ b/src/core/utils/time/timeTypes.ts
@@ -1,9 +1,7 @@
-interface RemainingTimeBreakdown {
+export interface RemainingTimeBreakdown {
   delta: number;
   days: number;
   hours: number;
   minutes: number;
   seconds: number;
 }
-
-export {RemainingTimeBreakdown};

--- a/src/countdown/util/countdownTypes.ts
+++ b/src/countdown/util/countdownTypes.ts
@@ -1,4 +1,4 @@
-interface CountdownProps {
+export interface CountdownProps {
   startDate: Date;
   testid?: string;
   titleMap?: {
@@ -13,10 +13,8 @@ interface CountdownProps {
   customClassName?: string;
 }
 
-interface CountdownItem {
+export interface CountdownItem {
   id: "days" | "hours" | "minutes" | "seconds";
   title: string;
   count: string | number;
 }
-
-export {CountdownItem, CountdownProps};

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,29 +1,58 @@
 import "./ui/reference/_colors.scss";
 import "./ui/reference/_measurement.scss";
 
-import FormField from "./form/field/FormField";
-import Input from "./form/input/Input";
-import PasswordInput from "./form/password-input/PasswordInput";
-import FileInput from "./form/input/file/FileInput";
-import CheckboxInput from "./form/input/checkbox/CheckboxInput";
-import RadioInput from "./form/input/radio/RadioInput";
-import RadioGroup from "./form/input/radio/group/RadioGroup";
-import TypeaheadInput from "./form/input/typeahead/TypeaheadInput";
-import TypeaheadSelect from "./select/typeahead/TypeaheadSelect";
-import Dropdown from "./dropdown/Dropdown";
-import List from "./list/List";
+import FormField, {
+  FormFieldProps as FormFieldComponentProps
+} from "./form/field/FormField";
+import Input, {InputProps as InputComponentProps} from "./form/input/Input";
+import PasswordInput, {
+  PasswordInputProps as PasswordInputComponentProps
+} from "./form/password-input/PasswordInput";
+import FileInput, {
+  FileInputProps as FileInputComponentProps
+} from "./form/input/file/FileInput";
+import CheckboxInput, {
+  CheckboxInputProps as CheckboxInputComponentProps
+} from "./form/input/checkbox/CheckboxInput";
+import RadioInput, {
+  RadioInputProps as RadioInputComponentProps,
+  RadioInputItem as RadioInputComponentItem
+} from "./form/input/radio/RadioInput";
+import RadioGroup, {
+  RadioGroupProps as RadioGroupComponentProps
+} from "./form/input/radio/group/RadioGroup";
+import TypeaheadInput, {
+  TypeaheadInputProps as TypeaheadInputComponentProps
+} from "./form/input/typeahead/TypeaheadInput";
+import TypeaheadSelect, {
+  TypeaheadSelectProps as TypeaheadSelectComponentProps
+} from "./select/typeahead/TypeaheadSelect";
+import Dropdown, {DropdownProps as DropdownComponentProps} from "./dropdown/Dropdown";
+import {
+  DropdownOption as DropdownComponentOption,
+  DropdownOptionSelectHandler as DropdownOptionSelectComponentHandler,
+  DropdownSelectedOption as DropdownSelectedComponentOption
+} from "./dropdown/list/item/DropdownListItem";
+import List, {ListProps as ListComponentProps} from "./list/List";
 import ListItem from "./list/item/ListItem";
-import Button from "./button/Button";
-import FileUploadButton from "./button/file-upload/FileUploadButton";
-import Spinner from "./spinner/Spinner";
-import Tab from "./tab/Tab";
-import Textarea from "./form/textarea/Textarea";
-import Avatar from "./avatar/Avatar";
-import {Toggle} from "./toggle/Toggle";
-import Switch from "./switch/Switch";
+import Button, {ButtonProps as ButtonComponentProps} from "./button/Button";
+import FileUploadButton, {
+  FileUploadButtonProps as FileUploadButtonComponentProps
+} from "./button/file-upload/FileUploadButton";
+import Spinner, {SpinnerProps as SpinnerComponentProps} from "./spinner/Spinner";
+import Tab, {TabItem as TabComponentItem, TabProps as TabComponentProps} from "./tab/Tab";
+import Textarea, {
+  TextareaProps as TextareaComponentProps
+} from "./form/textarea/Textarea";
+import Avatar, {AvatarProps as AvatarComponentProps} from "./avatar/Avatar";
+import {Toggle, ToggleProps as ToggleComponentProps} from "./toggle/Toggle";
+import Switch, {SwitchProps as SwitchComponentProps} from "./switch/Switch";
 import Countdown from "./countdown/Countdown";
 import useCountDownTimer from "./core/utils/hooks/useCountdownTimer";
-import ProgressBar from "./progress-bar/ProgressBar";
+import ProgressBar, {
+  ProgressBarProps as ProgressBarComponentProps
+} from "./progress-bar/ProgressBar";
+import {CountdownProps as CountdownComponentProps} from "../src/countdown/util/countdownTypes";
 
 export {
   // Components
@@ -54,29 +83,29 @@ export {
 };
 
 // Types
-export type FormFieldProps = any;
-export type InputProps = any;
-export type FileInputProps = any;
-export type PasswordInputProps = any;
-export type CheckboxInputProps = any;
-export type RadioInputProps = any;
-export type RadioInputItem = any;
-export type RadioGroupProps = any;
-export type TypeaheadInputProps = any;
-export type TypeaheadSelectProps = any;
-export type DropdownProps = any;
-export type DropdownOption = any;
-export type DropdownOptionSelectHandler = any;
-export type DropdownSelectedOption = any;
-export type ListProps = any;
-export type ButtonProps = any;
-export type FileUploadButtonProps = any;
-export type SpinnerProps = any;
-export type TabItem = any;
-export type TabProps = any;
-export type AvatarProps = any;
-export type ProgressBarProps = any;
-export type TextareaProps = any;
-export type ToggleProps = any;
-export type SwitchProps = any;
-export type CountdownProps = any;
+export type FormFieldProps = FormFieldComponentProps;
+export type InputProps = InputComponentProps;
+export type FileInputProps = FileInputComponentProps;
+export type PasswordInputProps = PasswordInputComponentProps;
+export type CheckboxInputProps = CheckboxInputComponentProps;
+export type RadioInputProps = RadioInputComponentProps;
+export type RadioInputItem = RadioInputComponentItem;
+export type RadioGroupProps = RadioGroupComponentProps;
+export type TypeaheadInputProps = TypeaheadInputComponentProps;
+export type TypeaheadSelectProps = TypeaheadSelectComponentProps;
+export type DropdownProps = DropdownComponentProps<any>;
+export type DropdownOption = DropdownComponentOption;
+export type DropdownOptionSelectHandler = DropdownOptionSelectComponentHandler;
+export type DropdownSelectedOption = DropdownSelectedComponentOption;
+export type ListProps = ListComponentProps;
+export type ButtonProps = ButtonComponentProps;
+export type FileUploadButtonProps = FileUploadButtonComponentProps;
+export type SpinnerProps = SpinnerComponentProps;
+export type TabItem = TabComponentItem;
+export type TabProps = TabComponentProps;
+export type AvatarProps = AvatarComponentProps;
+export type ProgressBarProps = ProgressBarComponentProps;
+export type TextareaProps = TextareaComponentProps;
+export type ToggleProps = ToggleComponentProps;
+export type SwitchProps = SwitchComponentProps;
+export type CountdownProps = CountdownComponentProps;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,37 +1,29 @@
 import "./ui/reference/_colors.scss";
 import "./ui/reference/_measurement.scss";
 
-import FormField, {FormFieldProps} from "./form/field/FormField";
-import Input, {InputProps} from "./form/input/Input";
-import PasswordInput, {PasswordInputProps} from "./form/password-input/PasswordInput";
-import FileInput, {FileInputProps} from "./form/input/file/FileInput";
-import CheckboxInput, {CheckboxInputProps} from "./form/input/checkbox/CheckboxInput";
-import RadioInput, {RadioInputProps, RadioInputItem} from "./form/input/radio/RadioInput";
-import RadioGroup, {RadioGroupProps} from "./form/input/radio/group/RadioGroup";
-import TypeaheadInput, {TypeaheadInputProps} from "./form/input/typeahead/TypeaheadInput";
-import TypeaheadSelect, {TypeaheadSelectProps} from "./select/typeahead/TypeaheadSelect";
-import Dropdown, {DropdownProps} from "./dropdown/Dropdown";
-import {
-  DropdownOption,
-  DropdownOptionSelectHandler,
-  DropdownSelectedOption
-} from "./dropdown/list/item/DropdownListItem";
-import List, {ListProps} from "./list/List";
+import FormField from "./form/field/FormField";
+import Input from "./form/input/Input";
+import PasswordInput from "./form/password-input/PasswordInput";
+import FileInput from "./form/input/file/FileInput";
+import CheckboxInput from "./form/input/checkbox/CheckboxInput";
+import RadioInput from "./form/input/radio/RadioInput";
+import RadioGroup from "./form/input/radio/group/RadioGroup";
+import TypeaheadInput from "./form/input/typeahead/TypeaheadInput";
+import TypeaheadSelect from "./select/typeahead/TypeaheadSelect";
+import Dropdown from "./dropdown/Dropdown";
+import List from "./list/List";
 import ListItem from "./list/item/ListItem";
-import Button, {ButtonProps} from "./button/Button";
-import FileUploadButton, {
-  FileUploadButtonProps
-} from "./button/file-upload/FileUploadButton";
-import Spinner, {SpinnerProps} from "./spinner/Spinner";
-import Tab, {TabItem, TabProps} from "./tab/Tab";
-import Textarea, {TextareaProps} from "./form/textarea/Textarea";
-import Avatar, {AvatarProps} from "./avatar/Avatar";
-import {Toggle, ToggleProps} from "./toggle/Toggle";
-import Switch, {SwitchProps} from "./switch/Switch";
+import Button from "./button/Button";
+import FileUploadButton from "./button/file-upload/FileUploadButton";
+import Spinner from "./spinner/Spinner";
+import Tab from "./tab/Tab";
+import Textarea from "./form/textarea/Textarea";
+import Avatar from "./avatar/Avatar";
+import {Toggle} from "./toggle/Toggle";
+import Switch from "./switch/Switch";
 import Countdown from "./countdown/Countdown";
 import useCountDownTimer from "./core/utils/hooks/useCountdownTimer";
-import ProgressBar, {ProgressBarProps} from "./progress-bar/ProgressBar";
-import {CountdownProps} from "../src/countdown/util/countdownTypes";
+import ProgressBar from "./progress-bar/ProgressBar";
 
 export {
   // Components
@@ -57,33 +49,34 @@ export {
   Textarea,
   Toggle,
   Switch,
-  // Types
-  FormFieldProps,
-  InputProps,
-  FileInputProps,
-  PasswordInputProps,
-  CheckboxInputProps,
-  RadioInputProps,
-  RadioInputItem,
-  RadioGroupProps,
-  TypeaheadInputProps,
-  TypeaheadSelectProps,
-  DropdownProps,
-  DropdownOption,
-  DropdownOptionSelectHandler,
-  DropdownSelectedOption,
-  ListProps,
-  ButtonProps,
-  FileUploadButtonProps,
-  SpinnerProps,
-  TabItem,
-  TabProps,
-  AvatarProps,
-  ProgressBarProps,
-  TextareaProps,
-  ToggleProps,
-  SwitchProps,
-  CountdownProps,
   // Hooks
   useCountDownTimer
 };
+
+// Types
+export type FormFieldProps = any;
+export type InputProps = any;
+export type FileInputProps = any;
+export type PasswordInputProps = any;
+export type CheckboxInputProps = any;
+export type RadioInputProps = any;
+export type RadioInputItem = any;
+export type RadioGroupProps = any;
+export type TypeaheadInputProps = any;
+export type TypeaheadSelectProps = any;
+export type DropdownProps = any;
+export type DropdownOption = any;
+export type DropdownOptionSelectHandler = any;
+export type DropdownSelectedOption = any;
+export type ListProps = any;
+export type ButtonProps = any;
+export type FileUploadButtonProps = any;
+export type SpinnerProps = any;
+export type TabItem = any;
+export type TabProps = any;
+export type AvatarProps = any;
+export type ProgressBarProps = any;
+export type TextareaProps = any;
+export type ToggleProps = any;
+export type SwitchProps = any;
+export type CountdownProps = any;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "outDir": "build",
     "lib": ["es6", "dom", "es2016", "es2017"],
     "sourceMap": true,
+    "isolatedModules": true,
 
     "jsx": "react",
     "declaration": true,


### PR DESCRIPTION
- `--isolatedModules` flag was added.
- Prop export type was changed.

```
Re-exporting a type when the '--isolatedModules' flag is provided requires using 'export type'.
```