### PR TITLE
feat(typeahead): Add type prop for TypeaheadInput

### DIFF
--- a/src/form/input/Input.tsx
+++ b/src/form/input/Input.tsx
@@ -11,7 +11,7 @@ import {
   IS_LAST_CHARACTER_DECIMAL_POINT_REGEX
 } from "../../core/utils/number/numberConstants";
 
-type InputTypes =
+export type InputTypes =
   | "checkbox"
   | "button"
   | "color"

--- a/src/form/input/typeahead/TypeaheadInput.tsx
+++ b/src/form/input/typeahead/TypeaheadInput.tsx
@@ -1,19 +1,20 @@
 import React, {useEffect} from "react";
 import classNames from "classnames";
 
-import Input from "../Input";
+import Input, {InputTypes} from "../Input";
 import useDebounce from "../../../core/utils/hooks/debounce";
 
 export interface TypeaheadInputProps {
   onQueryChange: (value: string) => void;
+  name: string;
+  placeholder: string;
+  type?: InputTypes;
   value?: string;
   testid?: string;
   customClassName?: string;
   id?: string;
-  name: string;
   isDisabled?: boolean;
   initialValue?: string;
-  placeholder: string;
   queryChangeDebounceTimeout?: number;
   onFocus?: React.ReactEventHandler<HTMLInputElement>;
   onBlur?: React.ReactEventHandler<HTMLInputElement>;
@@ -32,6 +33,7 @@ function TypeaheadInput(props: TypeaheadInputProps) {
     testid,
     placeholder,
     name,
+    type = "text",
     customClassName,
     onFocus,
     onBlur,
@@ -67,6 +69,7 @@ function TypeaheadInput(props: TypeaheadInputProps) {
       id={id}
       testid={testid}
       name={name}
+      type={type}
       placeholder={placeholder}
       onChange={handleInputChange}
       onFocus={onFocus}

--- a/src/form/input/typeahead/TypeaheadInput.tsx
+++ b/src/form/input/typeahead/TypeaheadInput.tsx
@@ -8,7 +8,7 @@ export interface TypeaheadInputProps {
   onQueryChange: (value: string) => void;
   name: string;
   placeholder: string;
-  type?: InputTypes;
+  type?: Extract<InputTypes, "text" | "number">;
   value?: string;
   testid?: string;
   customClassName?: string;

--- a/src/select/typeahead/TypeaheadSelect.tsx
+++ b/src/select/typeahead/TypeaheadSelect.tsx
@@ -23,8 +23,11 @@ export interface TypeaheadSelectProps {
   selectedOptions: DropdownOption[];
   dropdownOptions: DropdownOption[];
   onSelect: (option: DropdownOption) => void;
+  typeaheadProps: Pick<
+    TypeaheadInputProps,
+    "id" | "placeholder" | "name" | "onFocus" | "type"
+  >;
   testid?: string;
-  typeaheadProps: Pick<TypeaheadInputProps, "id" | "placeholder" | "name" | "onFocus">;
   onKeywordChange?: (value: string) => void;
   initialKeyword?: string;
   controlledKeyword?: string;
@@ -135,6 +138,7 @@ function TypeaheadSelect({
           inputContainerRef={typeaheadInputRef}
           id={typeaheadProps.id}
           name={typeaheadProps.name}
+          type={typeaheadProps.type}
           placeholder={typeaheadProps.placeholder}
           value={inputValue}
           onQueryChange={handleKeywordChange}

--- a/stories/5-Typeahead.stories.tsx
+++ b/stories/5-Typeahead.stories.tsx
@@ -34,6 +34,29 @@ storiesOf("Typeahead", module).add("Typeahead States", () => {
     keyword: ""
   };
 
+  const modelInitialState = {
+    options: [
+      {
+        id: "2005",
+        title: "2005"
+      },
+      {
+        id: "2015",
+        title: "2015"
+      },
+      {
+        id: "2021",
+        title: "2021"
+      }
+    ],
+    thirdOptions: [],
+    selectedOptions: [],
+    secondSelectedOptions: [],
+    thirdSelectedOptions: [],
+    areOptionsFetching: false,
+    keyword: ""
+  };
+
   return (
     <StoryFragment>
       <div style={{maxWidth: "350px"}}>
@@ -156,6 +179,29 @@ storiesOf("Typeahead", module).add("Typeahead States", () => {
                 typeaheadProps={{
                   placeholder: "Select Languages",
                   name: "language-test"
+                }}
+              />
+            </FormField>
+          )}
+        </StateProvider>
+
+        <StateProvider initialState={modelInitialState}>
+          {(state, setState) => (
+            <FormField label={"Select Model Year"}>
+              <TypeaheadSelect
+                dropdownOptions={modelInitialState.options}
+                selectedOptions={state.selectedOptions}
+                onSelect={(option) =>
+                  setState({
+                    ...state,
+                    selectedOptions: [...state.selectedOptions, option]
+                  })
+                }
+                onTagRemove={handleRemoveTag(state, setState)}
+                typeaheadProps={{
+                  placeholder: "Select Model",
+                  name: "model",
+                  type: "number"
                 }}
               />
             </FormField>


### PR DESCRIPTION
- `typeaheadProps` can use all input types.

![image](https://user-images.githubusercontent.com/44462260/118015978-88008d00-b35d-11eb-8c93-28dd6aa6256f.png)
