### PR TITLE
fix(toast-provider): Allow control of autoClose via ToastProvider

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -7,10 +7,5 @@ const req = require.context("../stories", true, /\.stories\.tsx$/);
 function loadStories() {
   req.keys().forEach(req);
 }
- 
-const ToastDecorator = storyFn => (
-  <ToastContextProvider>{storyFn()}</ToastContextProvider>
-)
 
 configure(loadStories, module);
-addDecorator(ToastDecorator);

--- a/src/toast/Toast.tsx
+++ b/src/toast/Toast.tsx
@@ -1,6 +1,6 @@
 import React, {useLayoutEffect} from "react";
 
-import {useToaster} from "./util/toastHooks";
+import {useToaster, useToastContext} from "./util/toastHooks";
 import {ToastContextState} from "./util/toastTypes";
 import ListItem from "../list/item/ListItem";
 import {DEFAULT_TOAST_TIMEOUT} from "./util/toastConstants";
@@ -13,14 +13,11 @@ export interface ToastProps {
 }
 
 function Toast({testid, data}: ToastProps) {
+  const [contextState] = useToastContext();
   const {hide} = useToaster();
-  const {
-    autoClose = true,
-    timeout = DEFAULT_TOAST_TIMEOUT,
-    render,
-    customClassName,
-    id: toastId
-  } = data;
+  const {timeout = DEFAULT_TOAST_TIMEOUT, render, customClassName, id: toastId} = data;
+  const autoClose =
+    typeof data.autoClose === "boolean" ? data.autoClose : contextState.autoCloseToasts;
 
   useLayoutEffect(() => {
     let timeoutId: NodeJS.Timeout;
@@ -32,7 +29,9 @@ function Toast({testid, data}: ToastProps) {
     }
 
     return () => {
-      clearTimeout(timeoutId);
+      if (timeoutId) {
+        clearTimeout(timeoutId);
+      }
     };
   }, [autoClose, timeout, hide, toastId]);
 

--- a/src/toast/ToastProvider.tsx
+++ b/src/toast/ToastProvider.tsx
@@ -15,6 +15,7 @@ ToastContext.displayName = "ToastContext";
 interface ToastContextProviderProps {
   children: React.ReactNode;
   customRootId?: string;
+  autoCloseToasts?: boolean;
 }
 
 /**
@@ -22,8 +23,15 @@ interface ToastContextProviderProps {
  * these children can then use the useToast hook to show toast messages
  */
 
-function ToastContextProvider({children, customRootId}: ToastContextProviderProps) {
-  const [state, dispatch] = useReducer(toastReducer, initialToastState);
+function ToastContextProvider({
+  children,
+  customRootId,
+  autoCloseToasts = true
+}: ToastContextProviderProps) {
+  const [state, dispatch] = useReducer(toastReducer, {
+    ...initialToastState,
+    autoCloseToasts
+  });
 
   return (
     <ToastContext.Provider value={[state, dispatch]}>

--- a/src/toast/util/toastConstants.ts
+++ b/src/toast/util/toastConstants.ts
@@ -3,7 +3,8 @@ import {ToastContextState} from "./toastTypes";
 const DEFAULT_TOAST_TIMEOUT = 4000;
 
 const initialToastState: ToastContextState = {
-  toastStack: []
+  toastStack: [],
+  autoCloseToasts: true
 };
 
 export {DEFAULT_TOAST_TIMEOUT, initialToastState};

--- a/src/toast/util/toastReducer.ts
+++ b/src/toast/util/toastReducer.ts
@@ -14,6 +14,7 @@ function toastReducer(state: ToastState, action: ToastAction): ToastState {
       const {toastData} = action;
 
       newState = {
+        ...state,
         toastStack: [
           ...state.toastStack.filter(not(isSameToast(toastData.id))),
           toastData
@@ -24,6 +25,7 @@ function toastReducer(state: ToastState, action: ToastAction): ToastState {
 
     case "HIDE": {
       newState = {
+        ...state,
         toastStack: state.toastStack.filter(not(isSameToast(action.toastId)))
       };
       break;
@@ -31,6 +33,7 @@ function toastReducer(state: ToastState, action: ToastAction): ToastState {
 
     case "HIDE_ALL": {
       newState = {
+        ...state,
         toastStack: []
       };
       break;
@@ -41,6 +44,7 @@ function toastReducer(state: ToastState, action: ToastAction): ToastState {
 
       if (currentIndex > -1) {
         newState = {
+          ...state,
           toastStack: updateAtIndex(state.toastStack, currentIndex, {
             ...state.toastStack[currentIndex],
             ...action.toastData

--- a/src/toast/util/toastTypes.ts
+++ b/src/toast/util/toastTypes.ts
@@ -21,4 +21,5 @@ export type ToastAction =
 
 export interface ToastContextState {
   toastStack: (Omit<ToastData, "id"> & {id: string})[];
+  autoCloseToasts: boolean;
 }

--- a/stories/8-Toast.stories.tsx
+++ b/stories/8-Toast.stories.tsx
@@ -7,12 +7,31 @@ import Button from "../src/button/Button";
 import {useToaster} from "../src/toast/util/toastHooks";
 import StoryFragment from "./utils/StoryFragment";
 import Toast from "../src/toast/Toast";
+import {ToastContextProvider} from "../src/toast/ToastProvider";
 
 function ToastComponent() {
+  return (
+    <StoryFragment>
+      <p>{"ToastProvider with default props"}</p>
+
+      <ToastContextProvider>
+        <ToastExamples />
+      </ToastContextProvider>
+
+      <p>{"ToastProvider with autoCloseToasts={false}"}</p>
+
+      <ToastContextProvider autoCloseToasts={false}>
+        <ToastExamples />
+      </ToastContextProvider>
+    </StoryFragment>
+  );
+}
+
+function ToastExamples() {
   const {display, update, hideAll} = useToaster();
 
   return (
-    <StoryFragment>
+    <div>
       <div className={"toast-button-group"}>
         <Button
           type={"button"}
@@ -150,7 +169,7 @@ function ToastComponent() {
           {"Toast with Close Button"}
         </Button>
       </div>
-    </StoryFragment>
+    </div>
   );
 }
 


### PR DESCRIPTION
Some projects might want Toasts to not autoClose by default. This adds a prop to ToastProvider that allows this functionality. You can still pass `autoClose: true` with `toast.display` callback to override ToastProvider's autoCloseToasts prop value.