### PR TITLE
fix: Add missing classnames to Toast and Input

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@hipo/react-ui-toolkit",
-  "version": "1.0.0-alpha.3.1.0",
+  "version": "1.0.0-alpha.3.1.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hipo/react-ui-toolkit",
-  "version": "1.0.0-alpha.3.1.0",
+  "version": "1.0.0-alpha.3.1.2",
   "description": "React based UI toolkit.",
   "main": "dist/index.js",
   "scripts": {

--- a/src/form/input/Input.tsx
+++ b/src/form/input/Input.tsx
@@ -83,11 +83,12 @@ function Input(props: InputProps) {
     setNumberSeparatorsForLocale
   ] = useState(() => getNumberSeparators(locale));
   const isNumberInput = type === "number";
-  const inputContainerClassName = classNames("input-container", customClassName);
+  const inputContainerClassName = classNames("input-container", customClassName, {
+    "input-container--type-number": isNumberInput
+  });
   const inputClassName = classNames("input", {
     "input--is-disabled": isDisabled,
-    "input--has-error": hasError,
-    "number-input": isNumberInput
+    "input--has-error": hasError
   });
   let finalValue = value;
 

--- a/src/form/input/Input.tsx
+++ b/src/form/input/Input.tsx
@@ -83,9 +83,11 @@ function Input(props: InputProps) {
     setNumberSeparatorsForLocale
   ] = useState(() => getNumberSeparators(locale));
   const isNumberInput = type === "number";
-  const inputContainerClassName = classNames("input-container", customClassName, {
-    "input-container--type-number": isNumberInput
-  });
+  const inputContainerClassName = classNames(
+    "input-container",
+    customClassName,
+    `input-container--type-${type}`
+  );
   const inputClassName = classNames("input", {
     "input--is-disabled": isDisabled,
     "input--has-error": hasError

--- a/src/toast/Toast.tsx
+++ b/src/toast/Toast.tsx
@@ -1,4 +1,5 @@
 import React, {useLayoutEffect} from "react";
+import classNames from "classnames";
 
 import {useToaster, useToastContext} from "./util/toastHooks";
 import {ToastContextState} from "./util/toastTypes";
@@ -37,7 +38,7 @@ function Toast({testid, data}: ToastProps) {
 
   return (
     <ToastItemContext.Provider value={{toastId}}>
-      <ListItem testid={testid} customClassName={customClassName}>
+      <ListItem testid={testid} customClassName={classNames("toast", customClassName)}>
         {render()}
       </ListItem>
     </ToastItemContext.Provider>


### PR DESCRIPTION
- Add `toast` container class
- Add `input-container--type-number` container class for `number input`