### PR TITLE
fix(number-input): Localization improvements

### DIFF
--- a/src/core/utils/number/numberTypes.ts
+++ b/src/core/utils/number/numberTypes.ts
@@ -1,8 +1,6 @@
-export interface FormatNumberOptions {
-  providedOptions: Omit<Intl.NumberFormatOptions, "style"> & {
-    locale?: string;
-  };
-}
+export type FormatNumberOptions = Omit<Intl.NumberFormatOptions, "style"> & {
+  locale?: string;
+};
 
 export interface ParseNumberOptions {
   locale?: string;

--- a/src/core/utils/number/numberTypes.ts
+++ b/src/core/utils/number/numberTypes.ts
@@ -1,3 +1,9 @@
+export interface FormatNumberOptions {
+  providedOptions: Omit<Intl.NumberFormatOptions, "style"> & {
+    locale?: string;
+  };
+}
+
 export interface ParseNumberOptions {
   locale?: string;
   maximumFractionDigits: number;

--- a/src/core/utils/number/numberUtils.ts
+++ b/src/core/utils/number/numberUtils.ts
@@ -1,4 +1,39 @@
-import {ParseNumberOptions} from "./numberTypes";
+import {FormatNumberOptions, ParseNumberOptions} from "./numberTypes";
+
+function formatNumber({providedOptions}: FormatNumberOptions) {
+  const {locale, ...otherOptions} = providedOptions;
+  const options = {
+    style: "decimal",
+    ...otherOptions
+  };
+
+  let numberFormatter: {
+    format: (x: number | bigint) => string;
+  };
+
+  try {
+    numberFormatter = new Intl.NumberFormat(
+      locale || [navigator.language, "en-GB"],
+      options
+    );
+  } catch (error) {
+    numberFormatter = {
+      format(x: number | bigint) {
+        return x.toLocaleString(locale);
+      }
+    };
+  }
+
+  return (value: number) => {
+    let formattedValue = "";
+
+    if (!Object.is(value, NaN)) {
+      formattedValue = numberFormatter.format(value);
+    }
+
+    return formattedValue;
+  };
+}
 
 /**
  * Coerces a number scientific notation. {@link https://observablehq.com/@mbostock/localized-number-parsing | Reference}
@@ -19,6 +54,7 @@ function parseNumber(
   const numeral = new RegExp(`[${numerals.join("")}]`, "g");
   const digitMapper = getDigit(new Map(numerals.map((d, i) => [d, i])));
   let parsedNumber = value
+    .replace(" ", "")
     .replace(new RegExp(`[${THOUSANDTHS_SEPARATOR}]`, "g"), "")
     .replace(new RegExp(`[${DECIMAL_NUMBER_SEPARATOR}]`), ".")
     .replace(numeral, digitMapper);
@@ -79,4 +115,10 @@ function getLocaleNumerals(locale = navigator.language) {
   return numerals;
 }
 
-export {parseNumber, getDigit, getNumberSeparators, mapDigitsToLocalVersion};
+export {
+  formatNumber,
+  parseNumber,
+  getDigit,
+  getNumberSeparators,
+  mapDigitsToLocalVersion
+};

--- a/src/core/utils/number/numberUtils.ts
+++ b/src/core/utils/number/numberUtils.ts
@@ -115,10 +115,29 @@ function getLocaleNumerals(locale = navigator.language) {
   return numerals;
 }
 
+function removeLeadingZeros(value: string) {
+  const decimalPart = value.split(".")[1];
+  let integerPart = value.split(".")[0];
+  let finalValue;
+
+  if (integerPart.length !== String(parseInt(integerPart)).length) {
+    integerPart = String(parseInt(integerPart));
+  }
+
+  if (value.match(/\.$/)?.length || decimalPart) {
+    finalValue = `${integerPart}.${decimalPart}`;
+  } else {
+    finalValue = integerPart;
+  }
+
+  return finalValue;
+}
+
 export {
   formatNumber,
   parseNumber,
   getDigit,
   getNumberSeparators,
-  mapDigitsToLocalVersion
+  mapDigitsToLocalVersion,
+  removeLeadingZeros
 };

--- a/src/core/utils/number/numberUtils.ts
+++ b/src/core/utils/number/numberUtils.ts
@@ -170,6 +170,10 @@ function removeLeadingZeros(locale = navigator.language, value: string) {
   return finalValue;
 }
 
+function getThousandthSeparatorCount(value: string) {
+  return formatNumber({locale: "en"})(parseFloat(value)).match(/,/g)?.length || 0;
+}
+
 export {
   formatNumber,
   parseNumber,
@@ -177,5 +181,6 @@ export {
   getNumberSeparators,
   getNegativeZero,
   mapDigitsToLocalVersion,
-  removeLeadingZeros
+  removeLeadingZeros,
+  getThousandthSeparatorCount
 };

--- a/src/core/utils/number/numberUtils.ts
+++ b/src/core/utils/number/numberUtils.ts
@@ -1,7 +1,7 @@
 import {FormatNumberOptions, ParseNumberOptions} from "./numberTypes";
 
-function formatNumber({providedOptions}: FormatNumberOptions) {
-  const {locale, ...otherOptions} = providedOptions;
+function formatNumber(formatNumberOptions: FormatNumberOptions) {
+  const {locale, ...otherOptions} = formatNumberOptions;
   const options = {
     style: "decimal",
     ...otherOptions
@@ -116,7 +116,9 @@ function getLocaleNumerals(locale = navigator.language) {
   return numerals;
 }
 
-// Locale and keyboard languange may not be the same setting. Should check with both of these.
+/**
+ * @returns Scientific and locale presentations of "-0" and "-00" values
+ */
 function getNegativeZero(locale = navigator.language) {
   const LOCALE_ZERO = getLocaleNumerals(locale)[0];
   const LOCALE_MINUS_SIGN = getNumberSeparators(locale).MINUS_SIGN;

--- a/src/form/input/Input.tsx
+++ b/src/form/input/Input.tsx
@@ -7,7 +7,8 @@ import {
   getNumberSeparators,
   parseNumber,
   mapDigitsToLocalVersion,
-  formatNumber
+  formatNumber,
+  removeLeadingZeros
 } from "../../core/utils/number/numberUtils";
 
 export type InputTypes =
@@ -167,9 +168,9 @@ function Input(props: InputProps) {
 
       if (newValue) {
         const formattedNewValue = parseNumber({locale, maximumFractionDigits}, newValue);
-        const isFormattedNewValueNotAValidNumber = Number.isNaN(
-          Number(formattedNewValue)
-        );
+        // Number("-") returns NaN. Should allow minus sign as first character.
+        const isFormattedNewValueNotAValidNumber =
+          newValue !== "-" && Number.isNaN(Number(formattedNewValue));
         let finalEventValue = formattedNewValue ? String(formattedNewValue) : "";
 
         // IF the parsed number is a valid and there is a decimal separator,
@@ -178,6 +179,12 @@ function Input(props: InputProps) {
           finalEventValue = String(formattedNewValue);
         } else if (isFormattedNewValueNotAValidNumber) {
           finalEventValue = value as string;
+        }
+
+        // IF there is shouldFormatToLocaleString or maximumFractionDigits props,
+        // value can't have leading zeros. Like 0,000,123 or 010.50
+        if (shouldFormatToLocaleString || maximumFractionDigits > 0) {
+          finalEventValue = removeLeadingZeros(finalEventValue);
         }
 
         event.currentTarget.value = finalEventValue;

--- a/src/form/input/Input.tsx
+++ b/src/form/input/Input.tsx
@@ -209,6 +209,34 @@ function Input(props: InputProps) {
           finalEventValue = value as string;
         }
 
+        // IF shouldFormatToLocaleString is defined, caret position should calculate according to thoudsandths separator count
+        if (shouldFormatToLocaleString) {
+          const numberFormatter = formatNumber({
+            maximumFractionDigits,
+            locale: "en"
+          });
+          const thousandthsSeparatorCount =
+            numberFormatter(parseFloat(finalEventValue)).match(/,/g)?.length || 0;
+          const prevValueThousandthsSeparatorCount =
+            numberFormatter(parseFloat(value as string)).match(/,/g)?.length || 0;
+          const element = event.currentTarget;
+          let caret = event.currentTarget.selectionStart || 0;
+
+          if (prevValueThousandthsSeparatorCount === thousandthsSeparatorCount + 1) {
+            caret -= 1;
+          } else if (
+            prevValueThousandthsSeparatorCount ===
+            thousandthsSeparatorCount - 1
+          ) {
+            caret += 1;
+          }
+
+          window.requestAnimationFrame(() => {
+            element.selectionStart = caret;
+            element.selectionEnd = caret;
+          });
+        }
+
         event.currentTarget.value = finalEventValue;
       }
     }

--- a/src/form/input/Input.tsx
+++ b/src/form/input/Input.tsx
@@ -6,7 +6,8 @@ import classNames from "classnames";
 import {
   getNumberSeparators,
   parseNumber,
-  mapDigitsToLocalVersion
+  mapDigitsToLocalVersion,
+  formatNumber
 } from "../../core/utils/number/numberUtils";
 
 export type InputTypes =
@@ -106,17 +107,22 @@ function Input(props: InputProps) {
 
   if (isNumberInput && typeof value === "string" && shouldFormatToLocaleString) {
     const [integerPart, decimalPart] = String(value).split(".");
+    const numberFormatter = formatNumber({
+      providedOptions: {
+        maximumFractionDigits,
+        locale
+      }
+    });
 
     // IF there is a decimal part or the value ends with ".",
     // make sure we add the decimal separator and map each digit on the decimal part to localized versions.
     // We shouldn't use parseInt or parseFloat with numberFormat util here because that removes zeros on the decimal part and disallows users to write something like: 10.01 or 10.102
     if (value.match(/\.$/)?.length || decimalPart) {
-      finalValue = `${mapDigitsToLocalVersion(
-        {locale},
-        integerPart
+      finalValue = `${numberFormatter(
+        parseInt(integerPart)
       )}${decimalSeparatorForLocale}${mapDigitsToLocalVersion({locale}, decimalPart)}`;
     } else if (integerPart) {
-      finalValue = mapDigitsToLocalVersion({locale}, integerPart);
+      finalValue = numberFormatter(parseInt(integerPart));
     }
   }
 
@@ -166,7 +172,8 @@ function Input(props: InputProps) {
         );
         let finalEventValue = formattedNewValue ? String(formattedNewValue) : "";
 
-        // IF the parsed number is a valid and there is a decimal separator, we need to save the number as it is so that decimal part doesn't disappear
+        // IF the parsed number is a valid and there is a decimal separator,
+        // we need to save the number as it is so that decimal part doesn't disappear
         if (!isFormattedNewValueNotAValidNumber && formattedNewValue.match(/./)?.length) {
           finalEventValue = String(formattedNewValue);
         } else if (isFormattedNewValueNotAValidNumber) {

--- a/stories/0-Form.stories.tsx
+++ b/stories/0-Form.stories.tsx
@@ -209,7 +209,10 @@ storiesOf("Form", module)
       <StateProvider initialState={""}>
         {(state, setState) => (
           <Fragment>
-            <FormField label={"ID or Passport Number – maxFractionDigits={0} - Can have leading zeros"}>
+            <FormField
+              label={
+                "ID or Passport Number – maxFractionDigits={0} - Can have leading zeros"
+              }>
               <Input
                 name={"id-number"}
                 type={"number"}

--- a/stories/0-Form.stories.tsx
+++ b/stories/0-Form.stories.tsx
@@ -307,6 +307,33 @@ storiesOf("Form", module)
           </Fragment>
         )}
       </StateProvider>
+
+      <br />
+
+      <StateProvider initialState={""}>
+        {(state, setState) => (
+          <Fragment>
+            <FormField
+              label={
+                'Budget (Locale) – maximumFractionDigits={4} - shouldFormatToLocaleString={true} - locale={"tr"}'
+              }>
+              <Input
+                name={"world-population"}
+                type={"number"}
+                localizationOptions={{
+                  maximumFractionDigits: 4,
+                  shouldFormatToLocaleString: true,
+                  locale: "tr"
+                }}
+                onChange={(e) => setState(e.currentTarget.value)}
+                value={state}
+              />
+            </FormField>
+
+            <p>{`event.currentTarget.value: ${state}`}</p>
+          </Fragment>
+        )}
+      </StateProvider>
     </Fragment>
   ))
   .add("Color Input", () => (

--- a/stories/0-Form.stories.tsx
+++ b/stories/0-Form.stories.tsx
@@ -209,7 +209,7 @@ storiesOf("Form", module)
       <StateProvider initialState={""}>
         {(state, setState) => (
           <Fragment>
-            <FormField label={"ID or Passport Number – maxFractionDigits={0}"}>
+            <FormField label={"ID or Passport Number – maxFractionDigits={0} - Can have leading zeros"}>
               <Input
                 name={"id-number"}
                 type={"number"}


### PR DESCRIPTION
### Description
- `numberFormatter` utility was added again.
- Input can have negative numbers with a minus sign.
- If the input has one of `shouldFormatToLocaleString`, `maximumFractionDigits` props or value is negative, can't have leading zeros. Also, if the first character of the value is a minus sign, the user can not type zero.
```
Leading zero: 0250 -> 250
Negative zero: -0 -> -  // If maximumFractionDigits is 0
Double leading zero: 00 -> 0 
```