### PR TITLE
feat(button): Add `ref` prop

### DIFF
--- a/src/button/Button.tsx
+++ b/src/button/Button.tsx
@@ -8,7 +8,7 @@ import "./_button.scss";
 
 export type ButtonProps = Omit<
   React.ButtonHTMLAttributes<HTMLButtonElement>,
-  "disabled"
+  "disabled" | "className"
 > & {
   children: React.ReactNode;
   testid?: string;

--- a/src/button/Button.tsx
+++ b/src/button/Button.tsx
@@ -17,12 +17,6 @@ export type ButtonProps = Omit<
   shouldPreventDefault?: boolean;
   shouldStopPropagation?: boolean;
   shouldFocus?: boolean;
-  onClick?: React.ReactEventHandler<HTMLButtonElement>;
-  onMouseOver?: React.ReactEventHandler<HTMLButtonElement>;
-  onMouseDown?: React.ReactEventHandler<HTMLButtonElement>;
-  onMouseUp?: React.ReactEventHandler<HTMLButtonElement>;
-  onFocus?: React.ReactEventHandler<HTMLButtonElement>;
-  onBlur?: React.ReactEventHandler<HTMLButtonElement>;
   ref?: React.RefObject<HTMLButtonElement>;
   shouldDisplaySpinner?: boolean;
   ariaLabel?: string;
@@ -45,11 +39,6 @@ const Button = React.forwardRef<HTMLButtonElement, Record<string, any>>(
       shouldDisplaySpinner,
       ariaLabel,
       isDisabled,
-      onMouseOver,
-      onMouseDown,
-      onMouseUp,
-      onFocus,
-      onBlur,
       ...rest
     } = props;
     const isButtonDisabled = Boolean(isDisabled || shouldDisplaySpinner);
@@ -73,11 +62,6 @@ const Button = React.forwardRef<HTMLButtonElement, Record<string, any>>(
         // eslint-disable-next-line jsx-a11y/no-autofocus
         autoFocus={shouldFocus}
         onClick={handleClick}
-        onMouseOver={handleMouseOver}
-        onMouseDown={onMouseDown}
-        onMouseUp={onMouseUp}
-        onFocus={handleFocus}
-        onBlur={onBlur}
         disabled={isButtonDisabled}
         aria-label={ariaLabel}
         {...rest}>
@@ -87,7 +71,7 @@ const Button = React.forwardRef<HTMLButtonElement, Record<string, any>>(
       </button>
     );
 
-    function handleClick(event: React.SyntheticEvent<HTMLButtonElement>) {
+    function handleClick(event: React.MouseEvent<HTMLButtonElement>) {
       if (onClick) {
         if (shouldPreventDefault) {
           event.preventDefault();
@@ -100,18 +84,6 @@ const Button = React.forwardRef<HTMLButtonElement, Record<string, any>>(
         if (!isButtonDisabled) {
           onClick(event);
         }
-      }
-    }
-
-    function handleMouseOver(event: React.SyntheticEvent<HTMLButtonElement>) {
-      if (onMouseOver) {
-        onMouseOver(event);
-      }
-    }
-
-    function handleFocus(event: React.SyntheticEvent<HTMLButtonElement>) {
-      if (onFocus) {
-        onFocus(event);
       }
     }
   }

--- a/src/button/Button.tsx
+++ b/src/button/Button.tsx
@@ -17,6 +17,7 @@ export interface ButtonProps {
   onFocus?: React.ReactEventHandler<HTMLButtonElement>;
   onBlur?: React.ReactEventHandler<HTMLButtonElement>;
   id?: string;
+  ref?: React.RefObject<HTMLButtonElement>;
   lang?: string;
   type?: "button" | "submit" | "reset";
   shouldDisplaySpinner?: boolean;
@@ -29,10 +30,18 @@ export interface ButtonProps {
   tabIndex?: number;
 }
 
+const RefButtonComponent = React.forwardRef<HTMLButtonElement, Record<string, any>>(
+  // eslint-disable-next-line prefer-arrow-callback
+  function RefButton(props, ref) {
+    return <button ref={ref} {...props} />;
+  }
+);
+
 function Button({
   testid,
   type = "button",
   id,
+  ref,
   lang,
   onClick,
   children,
@@ -65,7 +74,8 @@ function Button({
   );
 
   return (
-    <button
+    <RefButtonComponent
+      ref={ref}
       id={id}
       data-testid={testid}
       tabIndex={tabIndex}
@@ -85,7 +95,7 @@ function Button({
       {children}
 
       {shouldDisplaySpinner && spinnerContent}
-    </button>
+    </RefButtonComponent>
   );
 
   function handleClick(event: React.SyntheticEvent<HTMLButtonElement>) {

--- a/src/button/Button.tsx
+++ b/src/button/Button.tsx
@@ -23,13 +23,10 @@ export type ButtonProps = Omit<
   onMouseUp?: React.ReactEventHandler<HTMLButtonElement>;
   onFocus?: React.ReactEventHandler<HTMLButtonElement>;
   onBlur?: React.ReactEventHandler<HTMLButtonElement>;
-  id?: string;
   ref?: React.RefObject<HTMLButtonElement>;
-  lang?: string;
   shouldDisplaySpinner?: boolean;
   ariaLabel?: string;
   customClassName?: string;
-  tabIndex?: number;
 };
 
 const Button = React.forwardRef<HTMLButtonElement, Record<string, any>>(
@@ -38,9 +35,6 @@ const Button = React.forwardRef<HTMLButtonElement, Record<string, any>>(
     const {
       testid,
       type = "button",
-      id,
-      ref,
-      lang,
       onClick,
       children,
       customSpinner,
@@ -56,7 +50,7 @@ const Button = React.forwardRef<HTMLButtonElement, Record<string, any>>(
       onMouseUp,
       onFocus,
       onBlur,
-      tabIndex
+      ...rest
     } = props;
     const isButtonDisabled = Boolean(isDisabled || shouldDisplaySpinner);
     const containerClassName = classNames("button", customClassName, {
@@ -73,13 +67,9 @@ const Button = React.forwardRef<HTMLButtonElement, Record<string, any>>(
 
     return (
       <button
-        ref={ref}
-        id={id}
         data-testid={testid}
-        tabIndex={tabIndex}
         className={containerClassName}
         type={type}
-        lang={lang}
         // eslint-disable-next-line jsx-a11y/no-autofocus
         autoFocus={shouldFocus}
         onClick={handleClick}
@@ -89,7 +79,8 @@ const Button = React.forwardRef<HTMLButtonElement, Record<string, any>>(
         onFocus={handleFocus}
         onBlur={onBlur}
         disabled={isButtonDisabled}
-        aria-label={ariaLabel}>
+        aria-label={ariaLabel}
+        {...rest}>
         {children}
 
         {shouldDisplaySpinner && spinnerContent}

--- a/src/button/Button.tsx
+++ b/src/button/Button.tsx
@@ -19,7 +19,6 @@ export type ButtonProps = Omit<
   shouldFocus?: boolean;
   ref?: React.RefObject<HTMLButtonElement>;
   shouldDisplaySpinner?: boolean;
-  ariaLabel?: string;
   customClassName?: string;
 };
 
@@ -37,7 +36,6 @@ const Button = React.forwardRef<HTMLButtonElement, Record<string, any>>(
       shouldStopPropagation = true,
       shouldFocus,
       shouldDisplaySpinner,
-      ariaLabel,
       isDisabled,
       ...rest
     } = props;
@@ -65,7 +63,6 @@ const Button = React.forwardRef<HTMLButtonElement, Record<string, any>>(
         autoFocus={shouldFocus}
         onClick={handleClick}
         disabled={isButtonDisabled}
-        aria-label={ariaLabel}
         {...rest}>
         {children}
 

--- a/src/button/Button.tsx
+++ b/src/button/Button.tsx
@@ -6,10 +6,14 @@ import Spinner from "../spinner/Spinner";
 // SCSS import is moved here to be able to override spinner styles without nesting
 import "./_button.scss";
 
-export interface ButtonProps {
-  testid?: string;
+export type ButtonProps = Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, "disabled"> & {
   children: React.ReactNode;
+  testid?: string;
   customSpinner?: React.ReactNode;
+  isDisabled?: boolean;
+  shouldPreventDefault?: boolean;
+  shouldStopPropagation?: boolean;
+  shouldFocus?: boolean;
   onClick?: React.ReactEventHandler<HTMLButtonElement>;
   onMouseOver?: React.ReactEventHandler<HTMLButtonElement>;
   onMouseDown?: React.ReactEventHandler<HTMLButtonElement>;
@@ -19,112 +23,104 @@ export interface ButtonProps {
   id?: string;
   ref?: React.RefObject<HTMLButtonElement>;
   lang?: string;
-  type?: "button" | "submit" | "reset";
   shouldDisplaySpinner?: boolean;
-  isDisabled?: boolean;
-  shouldPreventDefault?: boolean;
-  shouldStopPropagation?: boolean;
-  shouldFocus?: boolean;
   ariaLabel?: string;
   customClassName?: string;
   tabIndex?: number;
-}
+};
 
-const RefButtonComponent = React.forwardRef<HTMLButtonElement, Record<string, any>>(
+const Button = React.forwardRef<HTMLButtonElement, Record<string, any>>(
   // eslint-disable-next-line prefer-arrow-callback
-  function RefButton(props, ref) {
-    return <button ref={ref} {...props} />;
+  function ButtonComponent(props: ButtonProps) {
+    const {
+      testid,
+      type = "button",
+      id,
+      ref,
+      lang,
+      onClick,
+      children,
+      customSpinner,
+      customClassName,
+      shouldPreventDefault = true,
+      shouldStopPropagation = true,
+      shouldFocus,
+      shouldDisplaySpinner,
+      ariaLabel,
+      isDisabled,
+      onMouseOver,
+      onMouseDown,
+      onMouseUp,
+      onFocus,
+      onBlur,
+      tabIndex
+    } = props;
+    const isButtonDisabled = Boolean(isDisabled || shouldDisplaySpinner);
+    const containerClassName = classNames("button", customClassName, {
+      "button--is-inactive": isButtonDisabled
+    });
+    const spinnerContent = customSpinner || (
+      <div className={"button__spinner-container"}>
+        <Spinner
+          customClassName={"button__spinner"}
+          aria-label={"Button spinner visible. Button inactivated."}
+        />
+      </div>
+    );
+
+    return (
+      <button
+        ref={ref}
+        id={id}
+        data-testid={testid}
+        tabIndex={tabIndex}
+        className={containerClassName}
+        type={type}
+        lang={lang}
+        // eslint-disable-next-line jsx-a11y/no-autofocus
+        autoFocus={shouldFocus}
+        onClick={handleClick}
+        onMouseOver={handleMouseOver}
+        onMouseDown={onMouseDown}
+        onMouseUp={onMouseUp}
+        onFocus={handleFocus}
+        onBlur={onBlur}
+        disabled={isButtonDisabled}
+        aria-label={ariaLabel}>
+        {children}
+
+        {shouldDisplaySpinner && spinnerContent}
+      </button>
+    );
+
+    function handleClick(event: React.SyntheticEvent<HTMLButtonElement>) {
+      if (onClick) {
+        if (shouldPreventDefault) {
+          event.preventDefault();
+        }
+
+        if (shouldStopPropagation) {
+          event.stopPropagation();
+        }
+
+        if (!isButtonDisabled) {
+          onClick(event);
+        }
+      }
+    }
+
+    function handleMouseOver(event: React.SyntheticEvent<HTMLButtonElement>) {
+      if (onMouseOver) {
+        onMouseOver(event);
+      }
+    }
+
+    function handleFocus(event: React.SyntheticEvent<HTMLButtonElement>) {
+      if (onFocus) {
+        onFocus(event);
+      }
+    }
   }
 );
-
-function Button({
-  testid,
-  type = "button",
-  id,
-  ref,
-  lang,
-  onClick,
-  children,
-  customSpinner,
-  customClassName,
-  shouldPreventDefault = true,
-  shouldStopPropagation = true,
-  shouldFocus,
-  shouldDisplaySpinner,
-  ariaLabel,
-  isDisabled,
-  onMouseOver,
-  onMouseDown,
-  onMouseUp,
-  onFocus,
-  onBlur,
-  tabIndex
-}: ButtonProps) {
-  const isButtonDisabled = Boolean(isDisabled || shouldDisplaySpinner);
-  const containerClassName = classNames("button", customClassName, {
-    "button--is-inactive": isButtonDisabled
-  });
-  const spinnerContent = customSpinner || (
-    <div className={"button__spinner-container"}>
-      <Spinner
-        customClassName={"button__spinner"}
-        aria-label={"Button spinner visible. Button inactivated."}
-      />
-    </div>
-  );
-
-  return (
-    <RefButtonComponent
-      ref={ref}
-      id={id}
-      data-testid={testid}
-      tabIndex={tabIndex}
-      className={containerClassName}
-      type={type}
-      lang={lang}
-      // eslint-disable-next-line jsx-a11y/no-autofocus
-      autoFocus={shouldFocus}
-      onClick={handleClick}
-      onMouseOver={handleMouseOver}
-      onMouseDown={onMouseDown}
-      onMouseUp={onMouseUp}
-      onFocus={handleFocus}
-      onBlur={onBlur}
-      disabled={isButtonDisabled}
-      aria-label={ariaLabel}>
-      {children}
-
-      {shouldDisplaySpinner && spinnerContent}
-    </RefButtonComponent>
-  );
-
-  function handleClick(event: React.SyntheticEvent<HTMLButtonElement>) {
-    if (onClick) {
-      if (shouldPreventDefault) {
-        event.preventDefault();
-      }
-
-      if (shouldStopPropagation) {
-        event.stopPropagation();
-      }
-
-      if (!isButtonDisabled) {
-        onClick(event);
-      }
-    }
-  }
-
-  function handleMouseOver(event: React.SyntheticEvent<HTMLButtonElement>) {
-    if (onMouseOver) {
-      onMouseOver(event);
-    }
-  }
-
-  function handleFocus(event: React.SyntheticEvent<HTMLButtonElement>) {
-    if (onFocus) {
-      onFocus(event);
-    }
-  }
-}
 
 export default Button;

--- a/src/button/Button.tsx
+++ b/src/button/Button.tsx
@@ -25,7 +25,7 @@ export type ButtonProps = Omit<
 
 const Button = React.forwardRef<HTMLButtonElement, Record<string, any>>(
   // eslint-disable-next-line prefer-arrow-callback
-  function ButtonComponent(props: ButtonProps) {
+  function ButtonComponent(props: ButtonProps, ref) {
     const {
       testid,
       type = "button",
@@ -56,6 +56,7 @@ const Button = React.forwardRef<HTMLButtonElement, Record<string, any>>(
 
     return (
       <button
+        ref={ref}
         data-testid={testid}
         className={containerClassName}
         type={type}

--- a/src/button/Button.tsx
+++ b/src/button/Button.tsx
@@ -6,7 +6,10 @@ import Spinner from "../spinner/Spinner";
 // SCSS import is moved here to be able to override spinner styles without nesting
 import "./_button.scss";
 
-export type ButtonProps = Omit<React.ButtonHTMLAttributes<HTMLButtonElement>, "disabled"> & {
+export type ButtonProps = Omit<
+  React.ButtonHTMLAttributes<HTMLButtonElement>,
+  "disabled"
+> & {
   children: React.ReactNode;
   testid?: string;
   customSpinner?: React.ReactNode;

--- a/src/button/Button.tsx
+++ b/src/button/Button.tsx
@@ -43,7 +43,8 @@ const Button = React.forwardRef<HTMLButtonElement, Record<string, any>>(
     } = props;
     const isButtonDisabled = Boolean(isDisabled || shouldDisplaySpinner);
     const containerClassName = classNames("button", customClassName, {
-      "button--is-inactive": isButtonDisabled
+      "button--is-inactive": isButtonDisabled,
+      "button--is-pending": shouldDisplaySpinner
     });
     const spinnerContent = customSpinner || (
       <div className={"button__spinner-container"}>

--- a/src/button/file-upload/FileUploadButton.tsx
+++ b/src/button/file-upload/FileUploadButton.tsx
@@ -10,42 +10,46 @@ export type FileUploadButtonProps = Omit<
   children: React.ReactNode;
   customClassName?: string;
   customLabelClassName?: string;
-  containerRef?: React.RefObject<HTMLDivElement>;
+  ref?: React.RefObject<HTMLLabelElement>;
   onFileSelect?: (
     files: React.SyntheticEvent<HTMLInputElement>["currentTarget"]["files"]
   ) => void;
 };
 
-function FileUploadButton({
-  onFileSelect,
-  children,
-  customClassName,
-  customLabelClassName,
-  containerRef,
-  ...fileInputProps
-}: FileUploadButtonProps) {
-  return (
-    <FileInput
-      {...fileInputProps}
-      ref={containerRef}
-      customClassName={classNames("file-upload-button", customClassName)}
-      customLabelClassName={classNames(
-        "file-upload-button__label",
-        "button",
-        customLabelClassName
-      )}
-      onChange={handleFileSelect}>
-      {children}
-    </FileInput>
-  );
+const FileUploadButton = React.forwardRef<HTMLLabelElement, Record<string, any>>(
+  // eslint-disable-next-line prefer-arrow-callback
+  function FileUploadButtonComponent(props: FileUploadButtonProps, ref) {
+    const {
+      onFileSelect,
+      children,
+      customClassName,
+      customLabelClassName,
+      ...fileInputProps
+    } = props;
 
-  function handleFileSelect(event: React.SyntheticEvent<HTMLInputElement>) {
-    const {files} = event.currentTarget;
+    return (
+      <FileInput
+        {...fileInputProps}
+        ref={ref}
+        customClassName={classNames("file-upload-button", customClassName)}
+        customLabelClassName={classNames(
+          "file-upload-button__label",
+          "button",
+          customLabelClassName
+        )}
+        onChange={handleFileSelect}>
+        {children}
+      </FileInput>
+    );
 
-    if (onFileSelect && files?.length) {
-      onFileSelect(files);
+    function handleFileSelect(event: React.SyntheticEvent<HTMLInputElement>) {
+      const {files} = event.currentTarget;
+
+      if (onFileSelect && files?.length) {
+        onFileSelect(files);
+      }
     }
   }
-}
+);
 
 export default FileUploadButton;

--- a/src/button/file-upload/FileUploadButton.tsx
+++ b/src/button/file-upload/FileUploadButton.tsx
@@ -10,6 +10,7 @@ export type FileUploadButtonProps = Omit<
   children: React.ReactNode;
   customClassName?: string;
   customLabelClassName?: string;
+  containerRef?: React.RefObject<HTMLDivElement>;
   onFileSelect?: (
     files: React.SyntheticEvent<HTMLInputElement>["currentTarget"]["files"]
   ) => void;
@@ -20,11 +21,13 @@ function FileUploadButton({
   children,
   customClassName,
   customLabelClassName,
+  containerRef,
   ...fileInputProps
 }: FileUploadButtonProps) {
   return (
     <FileInput
       {...fileInputProps}
+      ref={containerRef}
       customClassName={classNames("file-upload-button", customClassName)}
       customLabelClassName={classNames(
         "file-upload-button__label",

--- a/src/form/input/file/FileInput.tsx
+++ b/src/form/input/file/FileInput.tsx
@@ -18,10 +18,10 @@ export interface FileInputProps {
   customClassName?: string;
   customLabelClassName?: string;
   acceptedFileTypes?: string;
-  ref?: React.RefObject<HTMLDivElement>;
+  ref?: React.RefObject<HTMLLabelElement>;
 }
 
-const FileInput = React.forwardRef<HTMLDivElement, Record<string, any>>(
+const FileInput = React.forwardRef<HTMLLabelElement, Record<string, any>>(
   // eslint-disable-next-line prefer-arrow-callback
   function FileInputComponent(props: FileInputProps, ref) {
     const {
@@ -47,7 +47,7 @@ const FileInput = React.forwardRef<HTMLDivElement, Record<string, any>>(
     );
 
     return (
-      <div ref={ref} className={containerClassName}>
+      <div className={containerClassName}>
         <input
           data-testid={testid}
           type={"file"}
@@ -61,6 +61,7 @@ const FileInput = React.forwardRef<HTMLDivElement, Record<string, any>>(
         />
 
         <label
+          ref={ref}
           htmlFor={htmlFor}
           className={labelClassName}
           data-testid={`${testid}.label`}>

--- a/src/form/input/file/FileInput.tsx
+++ b/src/form/input/file/FileInput.tsx
@@ -18,57 +18,59 @@ export interface FileInputProps {
   customClassName?: string;
   customLabelClassName?: string;
   acceptedFileTypes?: string;
-  labelRef?: React.RefObject<HTMLLabelElement>;
+  ref?: React.RefObject<HTMLDivElement>;
 }
 
-function FileInput({
-  onChange,
-  children,
-  testid,
-  name,
-  htmlFor,
-  acceptedFileTypes = "image/png, image/jpeg, .pdf",
-  customSpinner,
-  customClassName,
-  customLabelClassName,
-  isPending,
-  isDisabled,
-  labelRef
-}: FileInputProps) {
-  const containerClassName = classNames("file-input__container", customClassName);
-  const isInputDisabled = isPending || isDisabled;
-  const labelClassName = classNames("file-input__label", customLabelClassName, {
-    "file-input__label--is-disabled": isInputDisabled
-  });
-  const spinnerContent = customSpinner || (
-    <Spinner customClassName={"file-input__spinner"} />
-  );
+const FileInput = React.forwardRef<HTMLDivElement, Record<string, any>>(
+  // eslint-disable-next-line prefer-arrow-callback
+  function FileInputComponent(props: FileInputProps, ref) {
+    const {
+      onChange,
+      children,
+      testid,
+      name,
+      htmlFor,
+      acceptedFileTypes = "image/png, image/jpeg, .pdf",
+      customSpinner,
+      customClassName,
+      customLabelClassName,
+      isPending,
+      isDisabled
+    } = props;
+    const containerClassName = classNames("file-input__container", customClassName);
+    const isInputDisabled = isPending || isDisabled;
+    const labelClassName = classNames("file-input__label", customLabelClassName, {
+      "file-input__label--is-disabled": isInputDisabled
+    });
+    const spinnerContent = customSpinner || (
+      <Spinner customClassName={"file-input__spinner"} />
+    );
 
-  return (
-    <div className={containerClassName}>
-      <input
-        data-testid={testid}
-        type={"file"}
-        value={""}
-        name={name}
-        className={"file-input"}
-        onChange={onChange}
-        id={htmlFor}
-        disabled={isInputDisabled}
-        accept={acceptedFileTypes}
-      />
+    return (
+      <div ref={ref} className={containerClassName}>
+        <input
+          data-testid={testid}
+          type={"file"}
+          value={""}
+          name={name}
+          className={"file-input"}
+          onChange={onChange}
+          id={htmlFor}
+          disabled={isInputDisabled}
+          accept={acceptedFileTypes}
+        />
 
-      <label
-        ref={labelRef}
-        htmlFor={htmlFor}
-        className={labelClassName}
-        data-testid={`${testid}.label`}>
-        {children}
+        <label
+          htmlFor={htmlFor}
+          className={labelClassName}
+          data-testid={`${testid}.label`}>
+          {children}
 
-        {isPending && spinnerContent}
-      </label>
-    </div>
-  );
-}
+          {isPending && spinnerContent}
+        </label>
+      </div>
+    );
+  }
+);
 
 export default FileInput;

--- a/stories/3-Button.stories.tsx
+++ b/stories/3-Button.stories.tsx
@@ -8,141 +8,144 @@ import StateProvider from "./utils/StateProvider";
 import SpinnerStorySample from "./utils/constants/spinner/SpinnerStorySample";
 import {useEffect, useRef} from "@storybook/addons";
 
-storiesOf("Button", module).add("Button States", () => {
-  const buttonRef = useRef<HTMLButtonElement | null>(null);
-  const fileUploadButtonRef = useRef<HTMLDivElement | null>(null);
+storiesOf("Button", module)
+  .add("Button States", () => {
+    const buttonRef = useRef<HTMLButtonElement | null>(null);
 
-  useEffect(() => {
-    console.log("FileUploadButton: ", fileUploadButtonRef.current);
-  }, []);
+    return (
+      <StoryFragment>
+        <Button type={"button"} onClick={(e) => alert("Thank You!")}>
+          {"Click Me"}
+        </Button>
 
-  return (
-    <StoryFragment>
-      <Button type={"button"} onClick={(e) => alert("Thank You!")}>
-        {"Click Me"}
-      </Button>
+        <br />
 
-      <br />
+        <Button type={"button"} onClick={(e) => alert("Thank You!")} isDisabled={true}>
+          {"Click Me - isDisabled"}
+        </Button>
 
-      <Button type={"button"} onClick={(e) => alert("Thank You!")} isDisabled={true}>
-        {"Click Me - isDisabled"}
-      </Button>
+        <br />
 
-      <br />
+        <StateProvider initialState={false}>
+          {(state, setState) => (
+            <Button
+              type={"button"}
+              onClick={() => setState(true)}
+              shouldDisplaySpinner={state}>
+              {"Click Me - shouldDisplaySpinner"}
+            </Button>
+          )}
+        </StateProvider>
 
-      <StateProvider initialState={false}>
-        {(state, setState) => (
-          <Button
-            type={"button"}
-            onClick={() => setState(true)}
-            shouldDisplaySpinner={state}>
-            {"Click Me - shouldDisplaySpinner"}
-          </Button>
-        )}
-      </StateProvider>
+        <br />
 
-      <br />
+        <Button
+          type={"button"}
+          onClick={(e) => alert("Thank You!")}
+          shouldDisplaySpinner={true}
+          customSpinner={<SpinnerStorySample />}>
+          {"Click Me - shouldDisplaySpinner - customSpinner"}
+        </Button>
 
-      <Button
-        type={"button"}
-        onClick={(e) => alert("Thank You!")}
-        shouldDisplaySpinner={true}
-        customSpinner={<SpinnerStorySample />}>
-        {"Click Me - shouldDisplaySpinner - customSpinner"}
-      </Button>
+        <br />
 
-      <br />
+        <Button
+          ref={buttonRef}
+          type={"button"}
+          onClick={() =>
+            alert(`Button width: ${buttonRef.current.getBoundingClientRect().width}`)
+          }>
+          {"Get Button Width"}
+        </Button>
+      </StoryFragment>
+    );
+  })
+  .add("Upload Button States", () => {
+    const fileUploadButtonRef = useRef<HTMLLabelElement | null>(null);
 
-      <Button
-        ref={buttonRef}
-        type={"button"}
-        onClick={() =>
-          alert(`Button width: ${buttonRef.current.getBoundingClientRect().width}`)
-        }>
-        {"Get Button Width"}
-      </Button>
+    useEffect(() => {
+      console.log("FileUploadButton: ", fileUploadButtonRef.current);
+    }, []);
 
-      <br />
-      <hr />
-      <br />
+    return (
+      <StoryFragment>
+        <FileUploadButton
+          onFileSelect={(files: FileList) =>
+            alert(
+              Array.from(files)
+                .map((file) => file.name)
+                .join(", ")
+            )
+          }
+          name={"photos"}
+          htmlFor={"photos"}>
+          {"Upload your photos"}
+        </FileUploadButton>
 
-      <FileUploadButton
-        onFileSelect={(files) =>
-          alert(
-            Array.from(files)
-              .map((file) => file.name)
-              .join(", ")
-          )
-        }
-        name={"photos"}
-        htmlFor={"photos"}>
-        {"Upload your photos"}
-      </FileUploadButton>
+        <br />
 
-      <br />
+        <FileUploadButton
+          onFileSelect={(files: FileList) =>
+            alert(
+              Array.from(files)
+                .map((file) => file.name)
+                .join(", ")
+            )
+          }
+          name={"second-photos"}
+          htmlFor={"second-photos"}
+          isDisabled={true}>
+          {"Upload your photos - isDisabled"}
+        </FileUploadButton>
 
-      <FileUploadButton
-        onFileSelect={(files) =>
-          alert(
-            Array.from(files)
-              .map((file) => file.name)
-              .join(", ")
-          )
-        }
-        name={"second-photos"}
-        htmlFor={"second-photos"}
-        isDisabled={true}>
-        {"Upload your photos - isDisabled"}
-      </FileUploadButton>
+        <br />
 
-      <br />
+        <FileUploadButton
+          onFileSelect={(files: FileList) =>
+            alert(
+              Array.from(files)
+                .map((file) => file.name)
+                .join(", ")
+            )
+          }
+          name={"second-photos"}
+          htmlFor={"second-photos"}
+          isPending={true}>
+          {"Upload your photos - isPending"}
+        </FileUploadButton>
 
-      <FileUploadButton
-        onFileSelect={(files) =>
-          alert(
-            Array.from(files)
-              .map((file) => file.name)
-              .join(", ")
-          )
-        }
-        name={"second-photos"}
-        htmlFor={"second-photos"}
-        isPending={true}>
-        {"Upload your photos - isPending"}
-      </FileUploadButton>
+        <br />
 
-      <br />
+        <FileUploadButton
+          onFileSelect={(files: FileList) =>
+            alert(
+              Array.from(files)
+                .map((file) => file.name)
+                .join(", ")
+            )
+          }
+          name={"second-photos"}
+          htmlFor={"second-photos"}
+          isPending={true}
+          customSpinner={<SpinnerStorySample />}>
+          {"Upload your photos - isPending - customSpinner"}
+        </FileUploadButton>
 
-      <FileUploadButton
-        onFileSelect={(files) =>
-          alert(
-            Array.from(files)
-              .map((file) => file.name)
-              .join(", ")
-          )
-        }
-        name={"second-photos"}
-        htmlFor={"second-photos"}
-        isPending={true}
-        customSpinner={<SpinnerStorySample />}>
-        {"Upload your photos - isPending - customSpinner"}
-      </FileUploadButton>
+        <br />
 
-      <br />
-
-      <FileUploadButton
-        containerRef={fileUploadButtonRef}
-        onFileSelect={(files) =>
-          alert(
-            Array.from(files)
-              .map((file) => file.name)
-              .join(", ")
-          )
-        }
-        name={"photos"}
-        htmlFor={"photos"}>
-        {"Get FileUploadButton Ref"}
-      </FileUploadButton>
-    </StoryFragment>
-  );
-});
+        <FileUploadButton
+          ref={fileUploadButtonRef}
+          onFileSelect={(files: FileList) =>
+            alert(
+              Array.from(files)
+                .map((file) => file.name)
+                .join(", ")
+            )
+          }
+          name={"photos"}
+          htmlFor={"photos"}>
+          {"Get FileUploadButton Ref"}
+        </FileUploadButton>
+      </StoryFragment>
+    );
+  });

--- a/stories/3-Button.stories.tsx
+++ b/stories/3-Button.stories.tsx
@@ -6,10 +6,15 @@ import FileUploadButton from "../src/button/file-upload/FileUploadButton";
 import StoryFragment from "./utils/StoryFragment";
 import StateProvider from "./utils/StateProvider";
 import SpinnerStorySample from "./utils/constants/spinner/SpinnerStorySample";
-import {useRef} from "@storybook/addons";
+import {useEffect, useRef} from "@storybook/addons";
 
 storiesOf("Button", module).add("Button States", () => {
   const buttonRef = useRef<HTMLButtonElement | null>(null);
+  const fileUploadButtonRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    console.log("FileUploadButton: ", fileUploadButtonRef.current);
+  }, []);
 
   return (
     <StoryFragment>
@@ -121,6 +126,22 @@ storiesOf("Button", module).add("Button States", () => {
         isPending={true}
         customSpinner={<SpinnerStorySample />}>
         {"Upload your photos - isPending - customSpinner"}
+      </FileUploadButton>
+
+      <br />
+
+      <FileUploadButton
+        containerRef={fileUploadButtonRef}
+        onFileSelect={(files) =>
+          alert(
+            Array.from(files)
+              .map((file) => file.name)
+              .join(", ")
+          )
+        }
+        name={"photos"}
+        htmlFor={"photos"}>
+        {"Get FileUploadButton Ref"}
       </FileUploadButton>
     </StoryFragment>
   );

--- a/stories/3-Button.stories.tsx
+++ b/stories/3-Button.stories.tsx
@@ -6,106 +6,122 @@ import FileUploadButton from "../src/button/file-upload/FileUploadButton";
 import StoryFragment from "./utils/StoryFragment";
 import StateProvider from "./utils/StateProvider";
 import SpinnerStorySample from "./utils/constants/spinner/SpinnerStorySample";
+import {useRef} from "@storybook/addons";
 
-storiesOf("Button", module).add("Button States", () => (
-  <StoryFragment>
-    <Button type={"button"} onClick={(e) => alert("Thank You!")}>
-      {"Click Me"}
-    </Button>
+storiesOf("Button", module).add("Button States", () => {
+  const buttonRef = useRef<HTMLButtonElement | null>(null);
 
-    <br />
+  return (
+    <StoryFragment>
+      <Button type={"button"} onClick={(e) => alert("Thank You!")}>
+        {"Click Me"}
+      </Button>
 
-    <Button type={"button"} onClick={(e) => alert("Thank You!")} isDisabled={true}>
-      {"Click Me - isDisabled"}
-    </Button>
+      <br />
 
-    <br />
+      <Button type={"button"} onClick={(e) => alert("Thank You!")} isDisabled={true}>
+        {"Click Me - isDisabled"}
+      </Button>
 
-    <StateProvider initialState={false}>
-      {(state, setState) => (
-        <Button
-          type={"button"}
-          onClick={() => setState(true)}
-          shouldDisplaySpinner={state}>
-          {"Click Me - shouldDisplaySpinner"}
-        </Button>
-      )}
-    </StateProvider>
+      <br />
 
-    <br />
+      <StateProvider initialState={false}>
+        {(state, setState) => (
+          <Button
+            type={"button"}
+            onClick={() => setState(true)}
+            shouldDisplaySpinner={state}>
+            {"Click Me - shouldDisplaySpinner"}
+          </Button>
+        )}
+      </StateProvider>
 
-    <Button
-      type={"button"}
-      onClick={(e) => alert("Thank You!")}
-      shouldDisplaySpinner={true}
-      customSpinner={<SpinnerStorySample />}>
-      {"Click Me - shouldDisplaySpinner - customSpinner"}
-    </Button>
+      <br />
 
-    <br />
-    <hr />
-    <br />
+      <Button
+        type={"button"}
+        onClick={(e) => alert("Thank You!")}
+        shouldDisplaySpinner={true}
+        customSpinner={<SpinnerStorySample />}>
+        {"Click Me - shouldDisplaySpinner - customSpinner"}
+      </Button>
 
-    <FileUploadButton
-      onFileSelect={(files) =>
-        alert(
-          Array.from(files)
-            .map((file) => file.name)
-            .join(", ")
-        )
-      }
-      name={"photos"}
-      htmlFor={"photos"}>
-      {"Upload your photos"}
-    </FileUploadButton>
+      <br />
 
-    <br />
+      <Button
+        ref={buttonRef}
+        type={"button"}
+        onClick={() =>
+          alert(`Button width: ${buttonRef.current.getBoundingClientRect().width}`)
+        }>
+        {"Get Button Width"}
+      </Button>
 
-    <FileUploadButton
-      onFileSelect={(files) =>
-        alert(
-          Array.from(files)
-            .map((file) => file.name)
-            .join(", ")
-        )
-      }
-      name={"second-photos"}
-      htmlFor={"second-photos"}
-      isDisabled={true}>
-      {"Upload your photos - isDisabled"}
-    </FileUploadButton>
+      <br />
+      <hr />
+      <br />
 
-    <br />
+      <FileUploadButton
+        onFileSelect={(files) =>
+          alert(
+            Array.from(files)
+              .map((file) => file.name)
+              .join(", ")
+          )
+        }
+        name={"photos"}
+        htmlFor={"photos"}>
+        {"Upload your photos"}
+      </FileUploadButton>
 
-    <FileUploadButton
-      onFileSelect={(files) =>
-        alert(
-          Array.from(files)
-            .map((file) => file.name)
-            .join(", ")
-        )
-      }
-      name={"second-photos"}
-      htmlFor={"second-photos"}
-      isPending={true}>
-      {"Upload your photos - isPending"}
-    </FileUploadButton>
+      <br />
 
-    <br />
+      <FileUploadButton
+        onFileSelect={(files) =>
+          alert(
+            Array.from(files)
+              .map((file) => file.name)
+              .join(", ")
+          )
+        }
+        name={"second-photos"}
+        htmlFor={"second-photos"}
+        isDisabled={true}>
+        {"Upload your photos - isDisabled"}
+      </FileUploadButton>
 
-    <FileUploadButton
-      onFileSelect={(files) =>
-        alert(
-          Array.from(files)
-            .map((file) => file.name)
-            .join(", ")
-        )
-      }
-      name={"second-photos"}
-      htmlFor={"second-photos"}
-      isPending={true}
-      customSpinner={<SpinnerStorySample />}>
-      {"Upload your photos - isPending - customSpinner"}
-    </FileUploadButton>
-  </StoryFragment>
-));
+      <br />
+
+      <FileUploadButton
+        onFileSelect={(files) =>
+          alert(
+            Array.from(files)
+              .map((file) => file.name)
+              .join(", ")
+          )
+        }
+        name={"second-photos"}
+        htmlFor={"second-photos"}
+        isPending={true}>
+        {"Upload your photos - isPending"}
+      </FileUploadButton>
+
+      <br />
+
+      <FileUploadButton
+        onFileSelect={(files) =>
+          alert(
+            Array.from(files)
+              .map((file) => file.name)
+              .join(", ")
+          )
+        }
+        name={"second-photos"}
+        htmlFor={"second-photos"}
+        isPending={true}
+        customSpinner={<SpinnerStorySample />}>
+        {"Upload your photos - isPending - customSpinner"}
+      </FileUploadButton>
+    </StoryFragment>
+  );
+});


### PR DESCRIPTION
- `ref` prop was added for can pass `ref` and use with `useRef` hook.
- It doesn't contain breaking change.
- It can be used like this;

```ts
const buttonRef = useRef<HTMLButtonElement | null>(null);

<Button ref={buttonRef} {...props} />
```
