### PR TITLE
feat(list): Add tests for List and ListItem

### DIFF
--- a/src/list/__snapshots__/list.test.tsx.snap
+++ b/src/list/__snapshots__/list.test.tsx.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<List /> should matches snapshot 1`] = `
+<ul
+  className="list"
+  data-testid="list"
+>
+  <li
+    className="list-item"
+    data-testid="list.item-0"
+  >
+    <span>
+      Hipo
+    </span>
+  </li>
+  <li
+    className="list-item"
+    data-testid="list.item-1"
+  >
+    <span>
+      Labs
+    </span>
+  </li>
+</ul>
+`;

--- a/src/list/item/ListItem.tsx
+++ b/src/list/item/ListItem.tsx
@@ -5,7 +5,7 @@ import classNames from "classnames";
 
 import {KEYBOARD_EVENT_KEY} from "../../core/utils/keyboard/keyboardEventConstants";
 
-interface ListItemProps {
+export interface ListItemProps {
   children?: React.ReactNode;
   testid?: string;
   customClassName?: string;

--- a/src/list/item/__snapshots__/list-item.test.tsx.snap
+++ b/src/list/item/__snapshots__/list-item.test.tsx.snap
@@ -1,0 +1,14 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<ListItem /> should matches snapshot 1`] = `
+<li
+  className="list-item"
+  data-testid="list-item"
+>
+  <p
+    data-testid="list-item.content"
+  >
+    Test
+  </p>
+</li>
+`;

--- a/src/list/item/list-item.test.tsx
+++ b/src/list/item/list-item.test.tsx
@@ -1,0 +1,73 @@
+import React from "react";
+import {render, cleanup, fireEvent} from "@testing-library/react";
+import "@testing-library/jest-dom";
+import {create} from "react-test-renderer";
+
+import {testA11y} from "../../core/utils/test/testUtils";
+import ListItem, {ListItemProps} from "./ListItem";
+
+describe("<ListItem />", () => {
+  afterEach(cleanup);
+
+  const defaultListItemProps: ListItemProps = {
+    testid: "list-item",
+    children: <p data-testid={"list-item.content"}>{"Test"}</p>
+  };
+
+  it("should render correctly", () => {
+    render(<ListItem {...defaultListItemProps} />);
+  });
+
+  it("should matches snapshot", () => {
+    const tree = create(<ListItem {...defaultListItemProps} />).toJSON();
+
+    expect(tree).toMatchSnapshot();
+  });
+
+  it("should pass a11y test", async () => {
+    const {container} = render(<ListItem {...defaultListItemProps} />);
+
+    await testA11y(container, {rules: {listitem: {enabled: false}}});
+  });
+
+  it("should render children correctly", () => {
+    const {getByTestId} = render(<ListItem {...defaultListItemProps} />);
+
+    expect(getByTestId("list-item")).toContainElement(getByTestId("list-item.content"));
+  });
+
+  it("clickableListItemProps should work correctly", () => {
+    const handleClick = jest.fn();
+    const {getByTestId, getByRole} = render(
+      <ListItem
+        clickableListItemProps={{onClick: handleClick, tabIndex: 2}}
+        {...defaultListItemProps}
+      />
+    );
+    const listItemButton = getByRole("button");
+
+    fireEvent.click(listItemButton);
+
+    expect(getByTestId("list-item")).toContainElement(listItemButton);
+    expect(listItemButton).toHaveAttribute("tabIndex", "2");
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("should run click event handler when enter key pressed", () => {
+    const handleClick = jest.fn();
+    const {getByRole} = render(
+      <ListItem
+        clickableListItemProps={{onClick: handleClick, tabIndex: 2}}
+        {...defaultListItemProps}
+      />
+    );
+
+    fireEvent.keyPress(getByRole("button"), {
+      key: "Enter",
+      code: "Enter",
+      keyCode: 13
+    });
+
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/list/list.test.tsx
+++ b/src/list/list.test.tsx
@@ -1,0 +1,102 @@
+import React from "react";
+import {render, cleanup, screen} from "@testing-library/react";
+import "@testing-library/jest-dom";
+import {create} from "react-test-renderer";
+
+import {testA11y} from "../core/utils/test/testUtils";
+import List, {ListProps} from "./List";
+import ListItem from "./item/ListItem";
+
+describe("<List />", () => {
+  afterEach(cleanup);
+
+  const listItems = ["Hipo", "Labs"];
+  const defaultListProps: ListProps = {
+    testid: "list",
+    items: listItems,
+    children: (item, testId, index) => (
+      <ListItem key={`list-item-${index}`} testid={testId}>
+        <span>{item}</span>
+      </ListItem>
+    )
+  };
+
+  it("should render correctly", () => {
+    render(<List {...defaultListProps} />);
+  });
+
+  it("should matches snapshot", () => {
+    const tree = create(<List {...defaultListProps} />).toJSON();
+
+    expect(tree).toMatchSnapshot();
+  });
+
+  it("should pass a11y test", async () => {
+    const {container} = render(<List {...defaultListProps} />);
+
+    await testA11y(container);
+  });
+
+  it("should render children correctly", () => {
+    const {getByTestId} = render(<List {...defaultListProps} />);
+
+    expect(getByTestId("list").children).toHaveLength(listItems.length);
+
+    for (let index = 0; index < listItems.length; index++) {
+      const listItemContent = getByTestId(`list.item-${index}`);
+
+      expect(getByTestId("list").children[index]).toEqual(listItemContent);
+    }
+  });
+
+  it("should render placeholder correctly", () => {
+    const {getByTestId} = render(
+      <List
+        placeholderProps={{
+          shouldDisplayPlaceholder: true,
+          placeholder: <p data-testid={"list.placeholder"}>{"Loading..."}</p>
+        }}
+        {...defaultListProps}
+      />
+    );
+
+    expect(getByTestId("list")).toContainElement(getByTestId("list.placeholder"));
+  });
+
+  it("should render empty state correctly", () => {
+    const {getByTestId} = render(
+      <List
+        emptyStateProps={{
+          shouldDisplayEmptyState: true,
+          emptyState: <p data-testid={"list.empty-state"}>{"Not found."}</p>
+        }}
+        {...defaultListProps}
+      />
+    );
+
+    expect(getByTestId("list")).toContainElement(getByTestId("list.empty-state"));
+  });
+
+  it("should render placeholder if both shouldDisplayPlaceholder and shouldDisplayEmptyState is true", () => {
+    const {getByTestId} = render(
+      <List
+        emptyStateProps={{
+          shouldDisplayEmptyState: true,
+          emptyState: (
+            <p data-testid={"list.empty-state"} className={"list--empty"}>
+              {"Not found."}
+            </p>
+          )
+        }}
+        placeholderProps={{
+          shouldDisplayPlaceholder: true,
+          placeholder: <p data-testid={"list.placeholder"}>{"Loading..."}</p>
+        }}
+        {...defaultListProps}
+      />
+    );
+
+    expect(getByTestId("list")).toContainElement(getByTestId("list.placeholder"));
+    expect(screen.queryByText("Not found.")).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
### Description

- Add test for `<List>` and `<ListItem>`

### Notes

- I could not test the `listItemKeyGenerator` prop on `<List>` component. I could not access `Fragment` because `key` is the only attribute that can be passed to `<Fragment>` . We can ignore this or maybe we can find a different way to render children.