### PR TITLE
fix(typeahead-input): Extend TypeaheadInputProps with InputProps

### DIFF
--- a/src/form/input/typeahead/TypeaheadInput.tsx
+++ b/src/form/input/typeahead/TypeaheadInput.tsx
@@ -1,55 +1,31 @@
 import React, {useEffect} from "react";
 import classNames from "classnames";
 
-import Input, {InputTypes} from "../Input";
+import Input, {InputProps, InputTypes} from "../Input";
 import useDebounce from "../../../core/utils/hooks/debounce";
 
-export interface TypeaheadInputProps {
+export type TypeaheadInputProps = Omit<
+  InputProps,
+  "onChange" | "type" | "customClassName" | "value"
+> & {
   onQueryChange: (value: string) => void;
-  name: string;
-  placeholder: string;
   type?: Extract<InputTypes, "text" | "number">;
   value?: string;
-  testid?: string;
-  customClassName?: string;
-  id?: string;
-  isDisabled?: boolean;
   initialValue?: string;
   queryChangeDebounceTimeout?: number;
-  onFocus?: React.ReactEventHandler<HTMLInputElement>;
-  onBlur?: React.ReactEventHandler<HTMLInputElement>;
-  onKeyDown?: React.KeyboardEventHandler<HTMLInputElement>;
-  leftIcon?: React.ReactNode;
-  rightIcon?: React.ReactNode;
-  role?: string;
-  children?: React.ReactNode;
-  inputContainerRef?: React.RefObject<HTMLDivElement>;
-}
+  customClassName?: string;
+};
 
 const DEFAULT_DEBOUNCE_TIMEOUT = 250;
 
-function TypeaheadInput(props: TypeaheadInputProps) {
-  const {
-    testid,
-    placeholder,
-    name,
-    type = "text",
-    customClassName,
-    onFocus,
-    onBlur,
-    id,
-    role,
-    onKeyDown,
-    onQueryChange,
-    isDisabled = false,
-    leftIcon,
-    rightIcon,
-    initialValue = "",
-    value,
-    queryChangeDebounceTimeout = DEFAULT_DEBOUNCE_TIMEOUT,
-    inputContainerRef
-  } = props;
-
+function TypeaheadInput({
+  onQueryChange,
+  value,
+  initialValue = "",
+  queryChangeDebounceTimeout = DEFAULT_DEBOUNCE_TIMEOUT,
+  customClassName,
+  ...otherProps
+}: TypeaheadInputProps) {
   const [inputValue, setInputValue] = useDebounce(
     onQueryChange,
     initialValue,
@@ -64,22 +40,10 @@ function TypeaheadInput(props: TypeaheadInputProps) {
 
   return (
     <Input
-      inputContainerRef={inputContainerRef}
-      customClassName={classNames("typeahead-input", customClassName)}
-      id={id}
-      testid={testid}
-      name={name}
-      type={type}
-      placeholder={placeholder}
-      onChange={handleInputChange}
-      onFocus={onFocus}
-      onBlur={onBlur}
-      onKeyDown={onKeyDown}
       value={inputValue}
-      isDisabled={isDisabled}
-      leftIcon={leftIcon}
-      rightIcon={rightIcon}
-      role={role}
+      customClassName={classNames("typeahead-input", customClassName)}
+      onChange={handleInputChange}
+      {...otherProps}
     />
   );
 

--- a/src/select/typeahead/TypeaheadSelect.tsx
+++ b/src/select/typeahead/TypeaheadSelect.tsx
@@ -176,7 +176,7 @@ function TypeaheadSelect({
     setMenuVisibility(true);
   }
 
-  function handleTypeaheadInputFocus(event: React.SyntheticEvent<HTMLInputElement>) {
+  function handleTypeaheadInputFocus(event: React.FocusEvent<HTMLInputElement>) {
     if (canOpenDropdownMenu && !isDisabled) {
       openDropdownMenu();
     }


### PR DESCRIPTION
### Description
- `TypeaheadInputProps` was extended with `InputProps`.
- Duplicated props were removed.

### Related Issue
- https://github.com/Hipo/react-ui-toolkit/issues/106