### PR TITLE
fix(input): Move `is-disabled` & `has-error` classNames to container

### DIFF
--- a/src/form/input/Input.tsx
+++ b/src/form/input/Input.tsx
@@ -97,12 +97,12 @@ function Input(props: InputProps) {
   const inputContainerClassName = classNames(
     "input-container",
     customClassName,
-    `input-container--type-${type}`
+    `input-container--type-${type}`,
+    {
+      "input-container--is-disabled": isDisabled,
+      "input-container--has-error": hasError
+    }
   );
-  const inputClassName = classNames("input", {
-    "input--is-disabled": isDisabled,
-    "input--has-error": hasError
-  });
   let finalValue = value;
 
   if (
@@ -161,7 +161,7 @@ function Input(props: InputProps) {
       )}
 
       <input
-        className={inputClassName}
+        className={"input"}
         type={isNumberInput ? "text" : type}
         autoComplete={autoComplete}
         value={finalValue}

--- a/src/form/input/_input.scss
+++ b/src/form/input/_input.scss
@@ -37,6 +37,6 @@
   }
 }
 
-.input--has-error {
+.input-container--has-error {
   border: 1px solid var(--invalid-text-color);
 }


### PR DESCRIPTION
### Breaking Change
- If `input--has-error` or `input--is-disabled` classNames are used in any project, these classNames should update with `input-container--has-error` and `input-container--is-disabled`.

### Related Ticket
- https://github.com/Hipo/react-ui-toolkit/issues/107