### PR TITLE
fix(input): Don't parse integer if integer part is empty

### DIFF
--- a/src/core/utils/number/numberUtils.ts
+++ b/src/core/utils/number/numberUtils.ts
@@ -156,7 +156,8 @@ function removeLeadingZeros(locale = navigator.language, value: string) {
     integerPart.length !== String(parseInt(integerPart)).length &&
     integerPart !== LOCALE_MINUS_SIGN &&
     integerPart !== LOCALE_NEGATIVE_ZERO &&
-    integerPart !== DEFAULT_NEGATIVE_ZERO
+    integerPart !== DEFAULT_NEGATIVE_ZERO &&
+    integerPart !== ""
   ) {
     integerPart = String(parseInt(integerPart));
   }


### PR DESCRIPTION
### Description
- When deleted a single integer character, the integer part equals `empty string` and `parseInt(<empty string>)` equals `NaN`.
- With this condition, `integerPart` will not be `NaN`. `0.5 -> .5`

Fixes: https://github.com/Hipo/react-ui-toolkit/issues/109