### PR TITLE
refactor(stories): Rename story names

### DIFF
--- a/stories/0-Form.stories.tsx
+++ b/stories/0-Form.stories.tsx
@@ -31,33 +31,37 @@ storiesOf("Form", module)
     </Fragment>
   ))
   .add("FormFieldWithInput", () => (
-    <FormField labelledBy={"Full Name"} label={"Full Name"}>
-      <Input
-        name={"fullName"}
-        placeholder={"Write your name"}
-        onChange={(e) => console.log(e.currentTarget.value)}
-      />
-    </FormField>
-  ))
-  .add("FormFieldWithInput.HasHelperMessage", () => (
-    <FormField
-      labelledBy={"Full Name"}
-      label={"Full Name"}
-      helperMessages={["You can include your middle name"]}>
-      <Input name="fullName" onChange={(e) => console.log(e.currentTarget.value)} />
-    </FormField>
-  ))
-  .add("FormFieldWithInput.HasErrorMessage", () => (
-    <FormField
-      labelledBy={"Full Name"}
-      label={"Full Name"}
-      errorMessages={["Please enter a full name"]}>
-      <Input
-        name={"fullName"}
-        hasError={true}
-        onChange={(e) => console.log(e.currentTarget.value)}
-      />
-    </FormField>
+    <StoryFragment>
+      <FormField labelledBy={"Full Name"} label={"Full Name"}>
+        <Input
+          name={"fullName"}
+          placeholder={"Write your name"}
+          onChange={(e) => console.log(e.currentTarget.value)}
+        />
+      </FormField>
+
+      <br />
+
+      <FormField
+        labelledBy={"Full Name"}
+        label={"Full Name"}
+        helperMessages={["You can include your middle name"]}>
+        <Input name="fullName" onChange={(e) => console.log(e.currentTarget.value)} />
+      </FormField>
+
+      <br />
+
+      <FormField
+        labelledBy={"Full Name"}
+        label={"Full Name"}
+        errorMessages={["Please enter a full name"]}>
+        <Input
+          name={"fullName"}
+          hasError={true}
+          onChange={(e) => console.log(e.currentTarget.value)}
+        />
+      </FormField>
+    </StoryFragment>
   ))
   .add("Textarea States", () => (
     <StoryFragment>

--- a/stories/0-Form.stories.tsx
+++ b/stories/0-Form.stories.tsx
@@ -12,7 +12,7 @@ import Textarea from "../src/form/textarea/Textarea";
 import StoryFragment from "./utils/StoryFragment";
 
 storiesOf("Form", module)
-  .add("Input States", () => (
+  .add("Input", () => (
     <Fragment>
       <Input
         name={"fullName"}
@@ -345,7 +345,7 @@ storiesOf("Form", module)
       />
     </FormField>
   ))
-  .add("Checkbox States", () => {
+  .add("Checkbox", () => {
     const initialState = {
       rememberMe: true,
       termsAndConditions: false,
@@ -405,7 +405,7 @@ storiesOf("Form", module)
       </StateProvider>
     );
   })
-  .add("Radio States", () => {
+  .add("Radio Input", () => {
     const initialState = {
       firstInput: {
         choices: [

--- a/stories/0-Form.stories.tsx
+++ b/stories/0-Form.stories.tsx
@@ -63,12 +63,12 @@ storiesOf("Form", module)
       </FormField>
     </StoryFragment>
   ))
-  .add("Textarea States", () => (
+  .add("Textarea", () => (
     <StoryFragment>
       <Textarea
         id={"textarea-fixed"}
         name={"Fixed size Textarea"}
-        placeholder={"Write your address"}
+        placeholder={"Fixed size Textarea"}
         onChange={(e) => {
           console.log(e.currentTarget.value);
         }}
@@ -79,20 +79,19 @@ storiesOf("Form", module)
       <Textarea
         id={"textarea-fixed"}
         name={"Disabled fixed size Textarea"}
-        placeholder={"Write your address"}
+        placeholder={"Disabled fixed size Textarea"}
         isDisabled={true}
         onChange={(e) => {
           console.log(e.currentTarget.value);
         }}
       />
-    </StoryFragment>
-  ))
-  .add("Textarea AutoSize", () => (
-    <StoryFragment>
+
+      <br />
+
       <Textarea
         id={"textarea-auto-size"}
         name={"Auto size Textarea"}
-        placeholder={"Write a paragraph"}
+        placeholder={"Auto size Textarea"}
         autoSizeProps={{}}
         onChange={(e) => {
           console.log(e.currentTarget.value);
@@ -104,30 +103,31 @@ storiesOf("Form", module)
       <Textarea
         id={"textarea-auto-size"}
         name={"Disabled auto size Textarea"}
-        placeholder={"Write a paragraph"}
+        placeholder={"Disabled auto size Textarea"}
         autoSizeProps={{}}
         isDisabled={true}
         onChange={(e) => {
           console.log(e.currentTarget.value);
         }}
       />
+
+      <br />
+
+      <FormField
+        labelledBy={"Address"}
+        label={"Address"}
+        errorMessages={["Please enter your address"]}>
+        <Textarea
+          id={"address"}
+          name={"Address"}
+          placeholder={"Textarea with error message"}
+          hasError={true}
+          onChange={(e) => {
+            console.log(e.currentTarget.value);
+          }}
+        />
+      </FormField>
     </StoryFragment>
-  ))
-  .add("Textarea.HasErrorMessage", () => (
-    <FormField
-      labelledBy={"Address"}
-      label={"Address"}
-      errorMessages={["Please enter your address"]}>
-      <Textarea
-        id={"address"}
-        name={"Address"}
-        placeholder={"Write your address"}
-        hasError={true}
-        onChange={(e) => {
-          console.log(e.currentTarget.value);
-        }}
-      />
-    </FormField>
   ))
   .add("Password Input", () => (
     <FormField label={"Password"}>

--- a/stories/1-Dropdown.stories.tsx
+++ b/stories/1-Dropdown.stories.tsx
@@ -8,7 +8,7 @@ import StoryFragment from "./utils/StoryFragment";
 import {initialState} from "./utils/constants/dropdown/dropdownStoryOptionConstants";
 
 storiesOf("Dropdown", module)
-  .add("Dropdown States", () => (
+  .add("Dropdown", () => (
     <StateProvider initialState={initialState.basic}>
       {(state, setState) => (
         <div className={"dropdown-story-container"}>

--- a/stories/10-Switch.stories.tsx
+++ b/stories/10-Switch.stories.tsx
@@ -5,7 +5,7 @@ import Switch from "../src/switch/Switch";
 import StateProvider from "./utils/StateProvider";
 import StoryFragment from "./utils/StoryFragment";
 
-storiesOf("Switch", module).add("Switch States", () => {
+storiesOf("Switch", module).add("Switch", () => {
   const initialState = {
     isSwitchOn: true,
     isDisabled: false

--- a/stories/11-Toggle.stories.tsx
+++ b/stories/11-Toggle.stories.tsx
@@ -6,7 +6,7 @@ import {initialState} from "./utils/constants/toggle/toggleStoryOptionConstants"
 import StateProvider from "./utils/StateProvider";
 
 storiesOf("Toggle", module)
-  .add("Toggle States", () => {
+  .add("Toggle", () => {
     return (
       <div style={{width: "500px"}}>
         <span>{"Switch Toggle - 2 Options"}</span>

--- a/stories/3-Button.stories.tsx
+++ b/stories/3-Button.stories.tsx
@@ -60,7 +60,7 @@ storiesOf("Button", module)
       </StoryFragment>
     );
   })
-  .add("Upload Button States", () => {
+  .add("Upload Button", () => {
     const fileUploadButtonRef = useRef<HTMLLabelElement | null>(null);
 
     useEffect(() => {

--- a/stories/3-Button.stories.tsx
+++ b/stories/3-Button.stories.tsx
@@ -9,7 +9,7 @@ import SpinnerStorySample from "./utils/constants/spinner/SpinnerStorySample";
 import {useEffect, useRef} from "@storybook/addons";
 
 storiesOf("Button", module)
-  .add("Button States", () => {
+  .add("Button", () => {
     const buttonRef = useRef<HTMLButtonElement | null>(null);
 
     return (

--- a/stories/5-Typeahead.stories.tsx
+++ b/stories/5-Typeahead.stories.tsx
@@ -10,7 +10,7 @@ import TypeaheadSelect from "../src/select/typeahead/TypeaheadSelect";
 const simulateAPICall = (timeout = 1000) =>
   new Promise((resolve) => setTimeout(resolve, timeout));
 
-storiesOf("Typeahead", module).add("Typeahead States", () => {
+storiesOf("Typeahead", module).add("Typeahead", () => {
   const initialState = {
     options: [
       {


### PR DESCRIPTION
### Description
**Renamed story names:**
- Renamed Input States as Input
- Renamed Checkbox States as Checkbox
- Renamed Radio States as Radio Input
- Renamed Dropdown States as Dropdown
- Renamed Switch States as Switch
- Renamed Toggle States as Toggle
- Renamed Button States as Button
- - Renamed Upload Button States as Button
- Renamed Typeahead States as Typeahead   

**Grouped stories:**
- Grouped FormField states in one story
- Grouped TextArea states in one story
  -  Add descriptive placeholders for each state.

Closes #116 