### PR TITLE
feat(tab): Add onTabChange prop

### DIFF
--- a/src/tab/Tab.tsx
+++ b/src/tab/Tab.tsx
@@ -18,6 +18,7 @@ export interface TabProps {
   testid?: string;
   initialActiveTabIndex?: number;
   customClassName?: string;
+  onTabChange?: (index: number) => void;
 }
 
 function Tab({
@@ -25,7 +26,8 @@ function Tab({
   items,
   initialActiveTabIndex = 0,
   children,
-  customClassName
+  customClassName,
+  onTabChange
 }: TabProps) {
   const [activeTabIndex, setActiveTabIndex] = useState(initialActiveTabIndex);
   const tabClassName = classNames("tab", customClassName);
@@ -50,6 +52,8 @@ function Tab({
 
   function handleChangeActiveTab(index: number) {
     setActiveTabIndex(index);
+
+    if (onTabChange) onTabChange(index);
   }
 }
 

--- a/stories/6-Tab.stories.tsx
+++ b/stories/6-Tab.stories.tsx
@@ -16,7 +16,11 @@ const tabItems: TabItem[] = [
 
 storiesOf("Tab", module).add("Tab", () => (
   <Fragment>
-    <Tab items={tabItems}>
+    <Tab
+      items={tabItems}
+      onTabChange={(index) => {
+        console.log("tab changed to index: ", index);
+      }}>
       {[<div key={0}>{"Home"}</div>, <div key={1}>{"Following"}</div>]}
     </Tab>
   </Fragment>


### PR DESCRIPTION
### Description
- Added optional `onTabChange` prop to the Tab component that triggers on tab change and takes index as parameter.
- Added example usage on Tab story page.
```diff
export interface TabProps {
  items: TabItem[];
  children: React.ReactNode[];
  testid?: string;
  initialActiveTabIndex?: number;
  customClassName?: string;
+ onTabChange?: (index: number) => void;
}
```
Closes #115 