### PR TITLE
feat(typeahead): Focus to input after option is selected

### DIFF
--- a/src/form/input/Input.tsx
+++ b/src/form/input/Input.tsx
@@ -56,6 +56,7 @@ export type InputProps = Omit<
     locale?: string;
     maximumFractionDigits?: number;
   };
+  inputRef?: React.RefObject<HTMLInputElement>;
 };
 
 /* eslint-disable complexity */
@@ -75,6 +76,7 @@ function Input(props: InputProps) {
     autoCorrect = "off",
     inputContainerRef,
     onChange,
+    inputRef,
     ...rest
   } = props;
   const {
@@ -161,6 +163,7 @@ function Input(props: InputProps) {
       )}
 
       <input
+        ref={inputRef}
         className={inputClassName}
         type={isNumberInput ? "text" : type}
         autoComplete={autoComplete}

--- a/src/form/input/typeahead/TypeaheadInput.tsx
+++ b/src/form/input/typeahead/TypeaheadInput.tsx
@@ -24,6 +24,7 @@ export interface TypeaheadInputProps {
   role?: string;
   children?: React.ReactNode;
   inputContainerRef?: React.RefObject<HTMLDivElement>;
+  inputRef?: React.RefObject<HTMLInputElement>;
 }
 
 const DEFAULT_DEBOUNCE_TIMEOUT = 250;
@@ -47,7 +48,8 @@ function TypeaheadInput(props: TypeaheadInputProps) {
     initialValue = "",
     value,
     queryChangeDebounceTimeout = DEFAULT_DEBOUNCE_TIMEOUT,
-    inputContainerRef
+    inputContainerRef,
+    inputRef
   } = props;
 
   const [inputValue, setInputValue] = useDebounce(
@@ -65,6 +67,7 @@ function TypeaheadInput(props: TypeaheadInputProps) {
   return (
     <Input
       inputContainerRef={inputContainerRef}
+      inputRef={inputRef}
       customClassName={classNames("typeahead-input", customClassName)}
       id={id}
       testid={testid}

--- a/src/select/typeahead/TypeaheadSelect.tsx
+++ b/src/select/typeahead/TypeaheadSelect.tsx
@@ -64,7 +64,9 @@ function TypeaheadSelect({
   initialKeyword = "",
   controlledKeyword
 }: TypeaheadSelectProps) {
-  const typeaheadInputRef = useRef<HTMLDivElement | null>(null);
+  const typeaheadInputContainerRef = useRef<HTMLDivElement | null>(null);
+  const typeaheadInputRef = useRef<HTMLInputElement | null>(null);
+
   const [isMenuOpen, setMenuVisibility] = useState(false);
   const [computedDropdownOptions, setComputedDropdownOptions] = useState(dropdownOptions);
   const [shouldFocusOnInput, setShouldFocusOnInput] = useState(false);
@@ -135,7 +137,8 @@ function TypeaheadSelect({
         <TypeaheadInput
           testid={`${testid}.search`}
           customClassName={"typeahead-select__input"}
-          inputContainerRef={typeaheadInputRef}
+          inputContainerRef={typeaheadInputContainerRef}
+          inputRef={typeaheadInputRef}
           id={typeaheadProps.id}
           name={typeaheadProps.name}
           type={typeaheadProps.type}
@@ -191,6 +194,7 @@ function TypeaheadSelect({
       onSelect(option!);
       setComputedDropdownOptions(dropdownOptions);
       setKeyword("");
+      setShouldFocusOnInput(true);
     }
   }
 


### PR DESCRIPTION
### Description
- Change inputRef target to the input instead of the inputContainer.
- Set ShouldFocusOnInput true after option selection.
- Input disappears after the selected options limit is reached, so it will not focus after that.
Closes #46 