### PR TITLE
fix(button): Fix prop types

### DIFF
--- a/src/button/Button.tsx
+++ b/src/button/Button.tsx
@@ -22,9 +22,9 @@ export type ButtonProps = Omit<
   customClassName?: string;
 };
 
-const Button = React.forwardRef<HTMLButtonElement, Record<string, any>>(
+const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
   // eslint-disable-next-line prefer-arrow-callback
-  function ButtonComponent(props: ButtonProps, ref) {
+  function ButtonComponent(props, ref) {
     const {
       testid,
       type = "button",

--- a/src/button/Button.tsx
+++ b/src/button/Button.tsx
@@ -17,7 +17,6 @@ export type ButtonProps = Omit<
   shouldPreventDefault?: boolean;
   shouldStopPropagation?: boolean;
   shouldFocus?: boolean;
-  ref?: React.RefObject<HTMLButtonElement>;
   shouldDisplaySpinner?: boolean;
   customClassName?: string;
 };

--- a/src/dropdown/Dropdown.tsx
+++ b/src/dropdown/Dropdown.tsx
@@ -35,7 +35,7 @@ export interface DropdownProps<OptionIdShape> {
   options: DropdownOption<OptionIdShape>[];
   selectedOption: DropdownSelectedOption<OptionIdShape>;
   onSelect: DropdownOptionSelectHandler<OptionIdShape>;
-  role: "listbox" | "menu" | "combobox";
+  role: "listbox" | "menu";
   testid?: string;
   header?: React.ReactNode;
   placeholder?: string;

--- a/src/dropdown/Dropdown.tsx
+++ b/src/dropdown/Dropdown.tsx
@@ -35,7 +35,7 @@ export interface DropdownProps<OptionIdShape> {
   options: DropdownOption<OptionIdShape>[];
   selectedOption: DropdownSelectedOption<OptionIdShape>;
   onSelect: DropdownOptionSelectHandler<OptionIdShape>;
-  role: "listbox" | "menu";
+  role: "listbox" | "menu" | "combobox";
   testid?: string;
   header?: React.ReactNode;
   placeholder?: string;
@@ -174,6 +174,7 @@ function Dropdown<OptionIdShape extends string>({
       onMouseUp={handleMouseUp}
       onClick={toggleDropdown}
       tabIndex={-1}
+      // @ts-ignore
       aria-haspopup={role}
       aria-expanded={isMenuOpen}
       shouldFocus={shouldFocusOnHeaderButton}>

--- a/src/form/password-input/PasswordInput.tsx
+++ b/src/form/password-input/PasswordInput.tsx
@@ -53,7 +53,7 @@ function PasswordInput({
           <Button
             testid={`${testid}-password-visibility-icon`}
             customClassName={passwordInputIconClassName}
-            ariaLabel={iconAriaLabel}
+            aria-label={iconAriaLabel}
             onClick={togglePasswordVisibility}
             shouldStopPropagation={false}
             shouldPreventDefault={false}>


### PR DESCRIPTION
### Description
- Changed forwardRef types.
- Removed explicit prop type in the component definition.
```diff
- const Button = React.forwardRef<HTMLButtonElement, Record<string, any>>(
+ const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(

-  function ButtonComponent(props: ButtonProps, ref) {
+  function ButtonComponent(props, ref) {
```
-  Fixed incompatible types in the `Dropdown` component
```
  Types of property ''aria-haspopup'' are incompatible.
    Type '"listbox" | "menu" | "combobox"' is not assignable to type 'boolean | "listbox" | "menu" | "dialog" | "false" | "true" | "tree" | "grid" | undefined'.
      Type '"combobox"' is not assignable to type 'boolean | "listbox" | "menu" | "dialog" | "false" | "true" | "tree" | "grid" | undefined'.
```

- Fixed typo in the `passwordInput` component.
```diff
- ariaLabel={iconAriaLabel}
+ aria-label={iconAriaLabel}
```

Closes #133 