### PR TITLE
feat(accordion): Create Accordion component

### DIFF
--- a/src/accordion/Accordion.tsx
+++ b/src/accordion/Accordion.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+
+import AccordionItem from "./item/AccordionItem";
+import {AccordionContextProvider} from "./AccordionProvider";
+export type AccordionProps = {
+  allowMultipleExpanded?: boolean;
+  allowZeroExpanded?: boolean;
+  defaultExpanded?: string[];
+  children: React.ReactNode;
+};
+
+function Accordion(props: AccordionProps) {
+  const {allowMultipleExpanded, allowZeroExpanded, defaultExpanded, children} = props;
+
+  return (
+    <AccordionContextProvider
+      allowMultipleExpanded={allowMultipleExpanded}
+      allowZeroExpanded={allowZeroExpanded}
+      defaultExpanded={defaultExpanded}>
+      <div>{children}</div>
+    </AccordionContextProvider>
+  );
+}
+
+Accordion.Body = () => <div />;
+Accordion.Item = AccordionItem;
+
+export default Accordion;

--- a/src/accordion/AccordionProvider.tsx
+++ b/src/accordion/AccordionProvider.tsx
@@ -1,0 +1,47 @@
+import React, {createContext, useReducer} from "react";
+
+import accordionReducer from "./util/accordionReducer";
+import {AccordionContextState, AccordionAction} from "./util/accordionTypes";
+
+const AccordionContext = createContext<
+  [AccordionContextState, React.Dispatch<AccordionAction>]
+>([
+  {
+    items: {},
+    allowMultipleExpanded: false,
+    allowZeroExpanded: false
+  },
+  () => undefined
+]);
+
+AccordionContext.displayName = "AccordionContext";
+
+interface AccordionContextProviderProps {
+  allowMultipleExpanded?: boolean;
+  allowZeroExpanded?: boolean;
+  defaultExpanded?: string[];
+  children: React.ReactNode;
+}
+
+function AccordionContextProvider({
+  allowMultipleExpanded = false,
+  allowZeroExpanded = false,
+  defaultExpanded = [],
+  children
+}: AccordionContextProviderProps) {
+  const items = defaultExpanded.reduce((o, key) => ({...o, [key]: true}), {});
+
+  const [state, dispatch] = useReducer(accordionReducer, {
+    allowMultipleExpanded,
+    allowZeroExpanded,
+    items
+  });
+
+  return (
+    <AccordionContext.Provider value={[state, dispatch]}>
+      {children}
+    </AccordionContext.Provider>
+  );
+}
+
+export {AccordionContext, AccordionContextProvider};

--- a/src/accordion/item/AccordionItem.tsx
+++ b/src/accordion/item/AccordionItem.tsx
@@ -1,0 +1,62 @@
+import classNames from "classnames";
+import React, {useState, useRef, useEffect} from "react";
+
+import "./_accordion-item.scss";
+
+import {useAccordionContext, useAccordion} from "../util/accordionHooks";
+
+export interface AccordionProps {
+  accordionId: string;
+  header: string;
+  children: React.ReactNode;
+}
+function AccordionItem({accordionId, header, children}: AccordionProps) {
+  const [state] = useAccordionContext();
+  const accordion = useAccordion();
+
+  const isOpen = state.items[accordionId];
+
+  const [height, setHeight] = useState<number | undefined>(isOpen ? undefined : 0);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    console.log(ref.current?.getBoundingClientRect().height);
+    setHeight(isOpen ? ref.current?.getBoundingClientRect().height : 0);
+  }, [isOpen]);
+
+  return (
+    <div className={"accordion__item"}>
+      <div
+        role={"button"}
+        onClick={handleClick}
+        onKeyPress={handleKeyPress}
+        tabIndex={0}
+        className={"accordion__header"}>
+        {isOpen ? "- " : "+ "}
+        {header}
+      </div>
+      <div
+        aria-expanded={isOpen}
+        className={classNames("accordion__content-wrap", {
+          "accordion__content-wrap--collapsed": !isOpen
+        })}
+        style={{height}}>
+        <div ref={ref} className={"accordion__content"}>
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+
+  function handleClick() {
+    accordion.toggle(accordionId);
+  }
+
+  function handleKeyPress(e: React.KeyboardEvent<HTMLDivElement>) {
+    if (e.key === "Enter") {
+      handleClick();
+    }
+  }
+}
+
+export default AccordionItem;

--- a/src/accordion/item/_accordion-item.scss
+++ b/src/accordion/item/_accordion-item.scss
@@ -1,0 +1,38 @@
+.accordion__item {
+  border: 1px solid var(--default-border-color);
+  border-bottom: none;
+  border-radius: var(--small-border-radius);
+
+  &:last-child {
+    border-bottom: 1px solid var(--default-border-color);
+  }
+}
+
+.accordion__header {
+  --accordion-header-bg: rgba(247, 247, 247, 1);
+  --accordion-header-padding: 12px 16px;
+
+  padding: var(--accordion-header-padding);
+
+  background-color: var(--accordion-header-bg);
+
+  cursor: pointer;
+}
+
+.accordion__content-wrap {
+  overflow: hidden;
+
+  visibility: visible;
+
+  transition: height 0.5s ease, visibility 0.5s ease;
+}
+
+.accordion__content-wrap--collapsed {
+  visibility: hidden;
+}
+
+.accordion__content {
+  --accordion-content-padding: 12px 16px;
+
+  padding: var(--accordion-content-padding);
+}

--- a/src/accordion/util/accordionHooks.ts
+++ b/src/accordion/util/accordionHooks.ts
@@ -1,0 +1,40 @@
+import {useCallback, useContext} from "react";
+
+import {AccordionContext} from "../AccordionProvider";
+
+/**
+ * @returns {Object} Current value of AccordionContext
+ */
+function useAccordionContext() {
+  const context = useContext(AccordionContext);
+
+  if (!context) {
+    throw new Error("Trying to consume AccordionContext outside of its provider.");
+  }
+
+  return context;
+}
+
+/**
+ * @returns {function} AccordionContext's state reducer's dispatch function
+ */
+function useAccordion() {
+  const dispatch = useAccordionContext()[1];
+
+  return {
+    /**
+     * Toggles an Accordion with a given id
+     */
+    toggle: useCallback(
+      (accordionId: string) => {
+        dispatch({
+          type: "TOGGLE",
+          accordionId
+        });
+      },
+      [dispatch]
+    )
+  };
+}
+
+export {useAccordionContext, useAccordion};

--- a/src/accordion/util/accordionReducer.ts
+++ b/src/accordion/util/accordionReducer.ts
@@ -1,0 +1,40 @@
+import {AccordionAction, AccordionState} from "./accordionTypes";
+
+function accordionReducer(
+  state: AccordionState,
+  action: AccordionAction
+): AccordionState {
+  let newState = state;
+
+  switch (action.type) {
+    case "TOGGLE": {
+      const items = {...state.items};
+      const {allowMultipleExpanded, allowZeroExpanded} = state;
+
+      const expandedItems = Object.keys(items);
+
+      if (items[action.accordionId]) {
+        if (allowZeroExpanded || expandedItems.length > 1) {
+          delete items[action.accordionId];
+        }
+      } else {
+        if (!allowMultipleExpanded) {
+          delete items[expandedItems[0]];
+        }
+        items[action.accordionId] = true;
+      }
+
+      newState = {
+        ...state,
+        items
+      };
+
+      break;
+    }
+    default:
+  }
+
+  return newState;
+}
+
+export default accordionReducer;

--- a/src/accordion/util/accordionTypes.ts
+++ b/src/accordion/util/accordionTypes.ts
@@ -1,0 +1,22 @@
+export interface AccordionData {
+  render: () => React.ReactNode;
+  id?: string;
+  customClassName?: string;
+}
+
+export interface AccordionContextState {
+  allowMultipleExpanded: boolean;
+  allowZeroExpanded: boolean;
+  items: {[key: string]: boolean};
+}
+
+export interface AccordionState {
+  allowMultipleExpanded: boolean;
+  allowZeroExpanded: boolean;
+  items: {[key: string]: boolean};
+}
+
+export type AccordionAction = {
+  type: "TOGGLE";
+  accordionId: string;
+};

--- a/stories/12-Accordion.stories.tsx
+++ b/stories/12-Accordion.stories.tsx
@@ -1,0 +1,52 @@
+import React, {Fragment} from "react";
+import {storiesOf} from "@storybook/react";
+import Accordion from "../src/accordion/Accordion";
+
+storiesOf("Accordion", module).add("Accordion", () => (
+  <Fragment>
+    <p>
+      {
+        'Accordion with defaultExpanded={["1"]} allowZeroExpanded={false} allowMultipleExpanded={false}'
+      }
+    </p>
+    <Accordion defaultExpanded={["1"]}>
+      <Accordion.Item accordionId="1" header="Accordion header 1">
+        Content of the Accordion 1
+      </Accordion.Item>
+      <Accordion.Item accordionId="2" header="Accordion header 2">
+        Content of the Accordion 2
+      </Accordion.Item>
+      <Accordion.Item accordionId="3" header="Accordion header 3">
+        Content of the Accordion 3
+      </Accordion.Item>
+    </Accordion>
+    <br />
+    <br />
+    <p>{"Accordion with allowZeroExpanded={true} allowMultipleExpanded={false}"}</p>
+    <Accordion allowZeroExpanded>
+      <Accordion.Item accordionId="1" header="Accordion header 1">
+        Content of the Accordion 1
+      </Accordion.Item>
+      <Accordion.Item accordionId="2" header="Accordion header 2">
+        Content of the Accordion 2
+      </Accordion.Item>
+      <Accordion.Item accordionId="3" header="Accordion header 3">
+        Content of the Accordion 3
+      </Accordion.Item>
+    </Accordion>
+    <br />
+    <br />
+    <p>{"Accordion with allowZeroExpanded={true} allowMultipleExpanded={true}"}</p>
+    <Accordion allowZeroExpanded allowMultipleExpanded>
+      <Accordion.Item accordionId="1" header="Accordion header 1">
+        Content of the Accordion 1
+      </Accordion.Item>
+      <Accordion.Item accordionId="2" header="Accordion header 2">
+        Content of the Accordion 2
+      </Accordion.Item>
+      <Accordion.Item accordionId="3" header="Accordion header 3">
+        Content of the Accordion 3
+      </Accordion.Item>
+    </Accordion>
+  </Fragment>
+));


### PR DESCRIPTION
### Description
- Implemented the Accordion component.
- Component has 3 optional props:
    - allowMultipleExpanded
    - allowZeroExpanded
    - defaultExpanded
- Each child should be wrapped with Accordion.Item component. Example usage can be found at `Accordion.stories.tsx`

Closes #129 