### PR TITLE
refactor(tag): Refactor tag with the clickable div element

### DIFF
--- a/src/tag/Tag.tsx
+++ b/src/tag/Tag.tsx
@@ -1,12 +1,9 @@
+import "./_tag.scss";
+
 import CloseIcon from "../ui/icons/close.svg";
 
 import React from "react";
 import classNames from "classnames";
-
-import Button from "../button/Button";
-
-// SCSS import is moved here to override Button styles without nesting
-import "./_tag.scss";
 
 export interface TagShape<Context = any> {
   id: string;
@@ -27,11 +24,13 @@ function Tag({testid, tag, onRemove, customClassName}: TagProps) {
   });
 
   return (
-    <Button
-      testid={testid}
-      customClassName={containerClassName}
-      onClick={handleRemove}
-      shouldStopPropagation={true}>
+    <div
+      role={"button"}
+      tabIndex={0}
+      data-testid={testid}
+      onKeyDown={handleKeyPress}
+      className={containerClassName}
+      onClick={handleRemove}>
       <div className={"tag__body"}>{tag.content}</div>
 
       {onRemove && (
@@ -41,12 +40,25 @@ function Tag({testid, tag, onRemove, customClassName}: TagProps) {
           aria-hidden={true}
         />
       )}
-    </Button>
+    </div>
   );
 
   function handleRemove() {
     if (onRemove) {
       onRemove(tag);
+    }
+  }
+
+  function handleKeyPress(event: React.KeyboardEvent<HTMLDivElement>) {
+    event.stopPropagation();
+    switch (event.key) {
+      case "Enter":
+      case "Del":
+      case "Backspace":
+        handleRemove();
+        break;
+      default:
+        break;
     }
   }
 }

--- a/src/tag/_tag.scss
+++ b/src/tag/_tag.scss
@@ -23,6 +23,8 @@
 }
 
 .tag--is-removable {
+  cursor: pointer;
+
   &:hover {
     path {
       stroke: var(--text-color);


### PR DESCRIPTION
### Description
To fix the bug with `Typeahead` usage in `FormField` component:
- Tag component is refactored with the clickable div element.

Closes #132