### PR TITLE
refactor(toggle): Refactor toggle with input element

### DIFF
--- a/src/toggle/item/ToggleItem.tsx
+++ b/src/toggle/item/ToggleItem.tsx
@@ -28,12 +28,38 @@ function ToggleItem({
     "toggle-item--is-disabled": isDisabled
   });
 
+  if (canSelectMultiple) {
+    return (
+      <ListItem
+        testid={testid}
+        customClassName={toggleItemClassName}
+        clickableListItemProps={isDisabled ? undefined : {onClick: handleToggle}}>
+        <label className={"toggle-item__label"}>
+          <input
+            type={"checkbox"}
+            className={"toggle-checkbox-input"}
+            checked={isSelected}
+            disabled={isDisabled}
+          />
+          {children}
+        </label>
+      </ListItem>
+    );
+  }
   return (
     <ListItem
       testid={testid}
       customClassName={toggleItemClassName}
       clickableListItemProps={isDisabled ? undefined : {onClick: handleToggle}}>
-      {children}
+      <label className={"toggle-item__label"}>
+        <input
+          type={"radio"}
+          className={"toggle-radio-input"}
+          checked={isSelected}
+          disabled={isDisabled}
+        />
+        {children}
+      </label>
     </ListItem>
   );
 

--- a/src/toggle/item/_toggle-item.scss
+++ b/src/toggle/item/_toggle-item.scss
@@ -39,4 +39,13 @@
     width: 100%;
     height: 100%;
   }
+
+  &__label {
+    cursor: pointer;
+  }
+}
+
+.toggle-checkbox-input,
+.toggle-radio-input {
+  display: none;
 }


### PR DESCRIPTION
### Description
Refactored Toggle component with input element,

*  If the toggle is multi-select, use checkbox input
*  If the toggle is single select, use radio input 

> Note: I am unable to use `RadioInput` and `CheckboxInput` components because they require the `item` prop and using icons.

Closes #144 