### PR TITLE
fix(number-input): Turn off formatting for Android devices

### DIFF
--- a/src/core/utils/device/deviceUtils.ts
+++ b/src/core/utils/device/deviceUtils.ts
@@ -1,0 +1,7 @@
+function isAndroid() {
+  const userAgent = navigator.userAgent || navigator.vendor;
+
+  return /android/i.test(userAgent);
+}
+
+export {isAndroid};

--- a/src/core/utils/number/numberUtils.ts
+++ b/src/core/utils/number/numberUtils.ts
@@ -1,3 +1,4 @@
+import {isAndroid} from "../device/deviceUtils";
 import {FormatNumberOptions, ParseNumberOptions} from "./numberTypes";
 
 function formatNumber(formatNumberOptions: FormatNumberOptions) {
@@ -36,21 +37,20 @@ function formatNumber(formatNumberOptions: FormatNumberOptions) {
 }
 
 /**
- * Coerces a number scientific notation. {@link https://observablehq.com/@mbostock/localized-number-parsing | Reference}
+ * Coerces a number to scientific notation. {@link https://observablehq.com/@mbostock/localized-number-parsing | Reference}
  * @param {object} options - An object includes parse number options
  * @param {string} options.locale - Default locale used is browser locale
  * @param {number} options.maximumFractionDigits - The maximum digit a decimal can have
  * @param {number} value - A number to convert to string
  * @returns {string} The value after coercing the given value to a scientific notation.
  */
-function parseNumber(
-  options: ParseNumberOptions = {locale: navigator.language, maximumFractionDigits: 0},
-  value: string
-) {
-  const {THOUSANDTHS_SEPARATOR, DECIMAL_NUMBER_SEPARATOR} = getNumberSeparators(
-    options.locale
-  );
-  const numerals = getLocaleNumerals(options.locale);
+function parseNumber(options: ParseNumberOptions, value: string) {
+  const {
+    locale = isAndroid() ? "en-US" : navigator.language,
+    maximumFractionDigits = 0
+  } = options;
+  const {THOUSANDTHS_SEPARATOR, DECIMAL_NUMBER_SEPARATOR} = getNumberSeparators(locale);
+  const numerals = getLocaleNumerals(locale);
   const numeral = new RegExp(`[${numerals.join("")}]`, "g");
   const digitMapper = getDigit(new Map(numerals.map((d, i) => [d, i])));
   let parsedNumber = value
@@ -59,12 +59,12 @@ function parseNumber(
     .replace(new RegExp(`[${DECIMAL_NUMBER_SEPARATOR}]`), ".")
     .replace(numeral, digitMapper);
 
-  if (typeof options.maximumFractionDigits === "number") {
+  if (typeof maximumFractionDigits === "number") {
     const [integerPart, decimalPart] = parsedNumber.split(".");
 
-    if (options.maximumFractionDigits === 0) {
+    if (maximumFractionDigits === 0) {
       parsedNumber = integerPart;
-    } else if (decimalPart && decimalPart.length === options.maximumFractionDigits + 1) {
+    } else if (decimalPart && decimalPart.length === maximumFractionDigits + 1) {
       return parsedNumber.slice(0, parsedNumber.length - 1);
     }
   } else {
@@ -86,10 +86,7 @@ function mapDigitsToLocalVersion(
   {locale = navigator.language}: {locale?: string},
   digits: string
 ) {
-  return digits
-    .split("")
-    .map(mapDigitToLocalVersion({locale}))
-    .join("");
+  return digits.split("").map(mapDigitToLocalVersion({locale})).join("");
 }
 
 function mapDigitToLocalVersion({locale = navigator.language}: {locale?: string}) {

--- a/src/form/input/Input.tsx
+++ b/src/form/input/Input.tsx
@@ -12,6 +12,8 @@ import {
   getNegativeZero,
   getThousandthSeparatorCount
 } from "../../core/utils/number/numberUtils";
+import {getLocalizationOptions} from "./util/inputUtils";
+import {InputLocalizationOptions} from "./util/inputTypes";
 
 export type InputTypes =
   | "checkbox"
@@ -50,11 +52,7 @@ export type InputProps = Omit<
   hasError?: boolean;
   customClassName?: string;
   onChange: React.ReactEventHandler<HTMLInputElement>;
-  localizationOptions?: {
-    shouldFormatToLocaleString?: boolean;
-    locale?: string;
-    maximumFractionDigits?: number;
-  };
+  localizationOptions?: InputLocalizationOptions;
 };
 
 const Input = React.forwardRef<HTMLInputElement, InputProps>(
@@ -80,7 +78,7 @@ const Input = React.forwardRef<HTMLInputElement, InputProps>(
       shouldFormatToLocaleString = false,
       locale,
       maximumFractionDigits = 0
-    } = localizationOptions;
+    } = getLocalizationOptions(localizationOptions);
     const [
       {
         DECIMAL_NUMBER_SEPARATOR: decimalSeparatorForLocale,

--- a/src/form/input/util/inputTypes.ts
+++ b/src/form/input/util/inputTypes.ts
@@ -1,0 +1,5 @@
+export type InputLocalizationOptions = {
+  shouldFormatToLocaleString?: boolean;
+  locale?: string;
+  maximumFractionDigits?: number;
+};

--- a/src/form/input/util/inputUtils.ts
+++ b/src/form/input/util/inputUtils.ts
@@ -1,0 +1,16 @@
+import {isAndroid} from "../../../core/utils/device/deviceUtils";
+import {InputLocalizationOptions} from "./inputTypes";
+
+function getLocalizationOptions(
+  localizationOptions: InputLocalizationOptions
+): InputLocalizationOptions {
+  return isAndroid()
+    ? {
+        shouldFormatToLocaleString: false,
+        locale: undefined,
+        maximumFractionDigits: localizationOptions.maximumFractionDigits
+      }
+    : localizationOptions;
+}
+
+export {getLocalizationOptions};


### PR DESCRIPTION
### Description
- The `Input` (A.K.A `NumberInput`) had weird behavior on some Android devices. When we try to write `1000`, the value was becoming `1.0001000`. This issue is the same with `1001`, `1008`, etc.
- We debugged this issue on an Android phone and we noticed this issue about `Intl.FormatNumber` but we haven't found any sensible reason. And we decided to exclude formatting for Android devices.
- `isAndroid` utility was added. That's way, all Android devices can only have scientific notation with the `en-US` locale.