### PR TITLE
fix: FileInput and FileUploadButton prop types

### DIFF
--- a/src/button/file-upload/FileUploadButton.tsx
+++ b/src/button/file-upload/FileUploadButton.tsx
@@ -3,12 +3,7 @@ import classNames from "classnames";
 
 import FileInput, {FileInputProps} from "../../form/input/file/FileInput";
 
-export type FileUploadButtonProps = Omit<
-  FileInputProps,
-  "children" | "onChange" | "children"
-> & {
-  children: React.ReactNode;
-  customClassName?: string;
+export type FileUploadButtonProps = Omit<FileInputProps, "onChange"> & {
   customLabelClassName?: string;
   ref?: React.RefObject<HTMLLabelElement>;
   onFileSelect?: (
@@ -16,9 +11,9 @@ export type FileUploadButtonProps = Omit<
   ) => void;
 };
 
-const FileUploadButton = React.forwardRef<HTMLLabelElement, Record<string, any>>(
+const FileUploadButton = React.forwardRef<HTMLLabelElement, FileUploadButtonProps>(
   // eslint-disable-next-line prefer-arrow-callback
-  function FileUploadButtonComponent(props: FileUploadButtonProps, ref) {
+  function FileUploadButtonComponent(props, ref) {
     const {
       onFileSelect,
       children,

--- a/src/form/input/file/FileInput.tsx
+++ b/src/form/input/file/FileInput.tsx
@@ -21,9 +21,9 @@ export interface FileInputProps {
   ref?: React.RefObject<HTMLLabelElement>;
 }
 
-const FileInput = React.forwardRef<HTMLLabelElement, Record<string, any>>(
+const FileInput = React.forwardRef<HTMLLabelElement, FileInputProps>(
   // eslint-disable-next-line prefer-arrow-callback
-  function FileInputComponent(props: FileInputProps, ref) {
+  function FileInputComponent(props, ref) {
     const {
       onChange,
       children,


### PR DESCRIPTION
### Description
- forwardRef types changed
- Duplicated types removed on `FileUploadButton`