### PR TITLE
feat(file-input): Allow multiple file upload

### DIFF
--- a/src/form/input/file/FileInput.tsx
+++ b/src/form/input/file/FileInput.tsx
@@ -19,6 +19,7 @@ export interface FileInputProps {
   customLabelClassName?: string;
   acceptedFileTypes?: string;
   ref?: React.RefObject<HTMLLabelElement>;
+  isMultiple?: boolean;
 }
 
 const FileInput = React.forwardRef<HTMLLabelElement, Record<string, any>>(
@@ -35,7 +36,8 @@ const FileInput = React.forwardRef<HTMLLabelElement, Record<string, any>>(
       customClassName,
       customLabelClassName,
       isPending,
-      isDisabled
+      isDisabled,
+      isMultiple
     } = props;
     const containerClassName = classNames("file-input__container", customClassName);
     const isInputDisabled = isPending || isDisabled;
@@ -58,6 +60,7 @@ const FileInput = React.forwardRef<HTMLLabelElement, Record<string, any>>(
           id={htmlFor}
           disabled={isInputDisabled}
           accept={acceptedFileTypes}
+          multiple={isMultiple}
         />
 
         <label


### PR DESCRIPTION
### Description
- `isMultiple` prop passed to input element's `multiple` attribute to allow multiple file upload