### PR TITLE
refactor(toast): Fix unnecessarily re-rendering all children of toast context on every state change

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2497,14 +2497,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/@jest/console/node_modules/slash": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/@jest/console/node_modules/supports-color": {
       "version": "7.2.0",
       "dev": true,
@@ -2627,14 +2619,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@jest/core/node_modules/slash": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/@jest/core/node_modules/strip-ansi": {
@@ -2792,14 +2776,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/@jest/reporters/node_modules/slash": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/@jest/reporters/node_modules/source-map": {
       "version": "0.6.1",
       "dev": true,
@@ -2941,14 +2917,6 @@
     },
     "node_modules/@jest/transform/node_modules/has-flag": {
       "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@jest/transform/node_modules/slash": {
-      "version": "3.0.0",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6009,49 +5977,6 @@
         "@babel/highlight": "^7.12.13"
       }
     },
-    "node_modules/@testing-library/dom/node_modules/@jest/types": {
-      "version": "26.6.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/istanbul-lib-coverage": "^2.0.0",
-        "@types/istanbul-reports": "^3.0.0",
-        "@types/node": "*",
-        "@types/yargs": "^15.0.0",
-        "chalk": "^4.0.0"
-      },
-      "engines": {
-        "node": ">= 10.14.2"
-      }
-    },
-    "node_modules/@testing-library/dom/node_modules/@types/istanbul-reports": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/istanbul-lib-report": "*"
-      }
-    },
-    "node_modules/@testing-library/dom/node_modules/ansi-regex": {
-      "version": "5.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@testing-library/dom/node_modules/aria-query": {
-      "version": "4.2.2",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@babel/runtime": "^7.10.2",
-        "@babel/runtime-corejs3": "^7.10.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      }
-    },
     "node_modules/@testing-library/dom/node_modules/chalk": {
       "version": "4.1.1",
       "dev": true,
@@ -6116,39 +6041,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/@testing-library/dom/node_modules/pretty-format": {
-      "version": "26.6.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@jest/types": "^26.6.2",
-        "ansi-regex": "^5.0.0",
-        "ansi-styles": "^4.0.0",
-        "react-is": "^17.0.1"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/@testing-library/dom/node_modules/pretty-format/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@testing-library/dom/node_modules/react-is": {
-      "version": "17.0.2",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/@testing-library/jest-dom": {
       "version": "5.12.0",
       "dev": true,
@@ -6181,18 +6073,6 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@testing-library/jest-dom/node_modules/aria-query": {
-      "version": "4.2.2",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@babel/runtime": "^7.10.2",
-        "@babel/runtime-corejs3": "^7.10.2"
-      },
-      "engines": {
-        "node": ">=6.0"
       }
     },
     "node_modules/@testing-library/jest-dom/node_modules/chalk": {
@@ -6910,87 +6790,6 @@
         }
       }
     },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/@nodelib/fs.stat": {
-      "version": "2.0.4",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/array-union": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/dir-glob": {
-      "version": "3.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "path-type": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/fast-glob": {
-      "version": "3.2.5",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.stat": "^2.0.2",
-        "@nodelib/fs.walk": "^1.2.3",
-        "glob-parent": "^5.1.0",
-        "merge2": "^1.3.0",
-        "micromatch": "^4.0.2",
-        "picomatch": "^2.2.1"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/globby": {
-      "version": "11.0.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array-union": "^2.1.0",
-        "dir-glob": "^3.0.1",
-        "fast-glob": "^3.1.1",
-        "ignore": "^5.1.4",
-        "merge2": "^1.3.0",
-        "slash": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/ignore": {
-      "version": "5.1.8",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
       "version": "7.3.5",
       "dev": true,
@@ -7004,19 +6803,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/slash": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/yallist": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/@typescript-eslint/visitor-keys": {
       "version": "4.23.0",
@@ -8034,14 +7820,6 @@
     },
     "node_modules/babel-jest/node_modules/has-flag": {
       "version": "4.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/babel-jest/node_modules/slash": {
-      "version": "3.0.0",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10729,17 +10507,6 @@
         "node": ">=8.9.0"
       }
     },
-    "node_modules/css-loader/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/css-loader/node_modules/postcss": {
       "version": "8.2.15",
       "dev": true,
@@ -10833,11 +10600,6 @@
       "engines": {
         "node": ">=0.10.0"
       }
-    },
-    "node_modules/css-loader/node_modules/yallist": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/css-modules-loader-core": {
       "version": "1.1.0",
@@ -12623,14 +12385,6 @@
         "eslint": "^7.5.0"
       }
     },
-    "node_modules/eslint-plugin-testing-library/node_modules/@nodelib/fs.stat": {
-      "version": "2.0.5",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/eslint-plugin-testing-library/node_modules/@typescript-eslint/experimental-utils": {
       "version": "4.28.1",
       "dev": true,
@@ -12724,41 +12478,6 @@
         "url": "https://opencollective.com/typescript-eslint"
       }
     },
-    "node_modules/eslint-plugin-testing-library/node_modules/array-union": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/eslint-plugin-testing-library/node_modules/debug": {
-      "version": "4.3.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "2.1.2"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/eslint-plugin-testing-library/node_modules/dir-glob": {
-      "version": "3.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "path-type": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/eslint-plugin-testing-library/node_modules/eslint-scope": {
       "version": "5.1.1",
       "dev": true,
@@ -12796,78 +12515,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/eslint-plugin-testing-library/node_modules/esrecurse": {
-      "version": "4.3.0",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "dependencies": {
-        "estraverse": "^5.2.0"
-      },
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
-    "node_modules/eslint-plugin-testing-library/node_modules/esrecurse/node_modules/estraverse": {
-      "version": "5.2.0",
-      "dev": true,
-      "license": "BSD-2-Clause",
-      "engines": {
-        "node": ">=4.0"
-      }
-    },
-    "node_modules/eslint-plugin-testing-library/node_modules/fast-glob": {
-      "version": "3.2.6",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@nodelib/fs.stat": "^2.0.2",
-        "@nodelib/fs.walk": "^1.2.3",
-        "glob-parent": "^5.1.2",
-        "merge2": "^1.3.0",
-        "micromatch": "^4.0.4"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/eslint-plugin-testing-library/node_modules/globby": {
-      "version": "11.0.4",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array-union": "^2.1.0",
-        "dir-glob": "^3.0.1",
-        "fast-glob": "^3.1.1",
-        "ignore": "^5.1.4",
-        "merge2": "^1.3.0",
-        "slash": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/eslint-plugin-testing-library/node_modules/ignore": {
-      "version": "5.1.8",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/eslint-plugin-testing-library/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/eslint-plugin-testing-library/node_modules/semver": {
       "version": "7.3.5",
       "dev": true,
@@ -12881,33 +12528,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/eslint-plugin-testing-library/node_modules/slash": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/eslint-plugin-testing-library/node_modules/tsutils": {
-      "version": "3.21.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^1.8.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      },
-      "peerDependencies": {
-        "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
-      }
-    },
-    "node_modules/eslint-plugin-testing-library/node_modules/yallist": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/eslint-scope": {
       "version": "4.0.3",
@@ -13042,11 +12662,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/eslint/node_modules/fast-deep-equal": {
-      "version": "3.1.3",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/eslint/node_modules/file-entry-cache": {
       "version": "6.0.1",
       "dev": true,
@@ -13109,17 +12724,6 @@
       "version": "1.0.0",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/eslint/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
     },
     "node_modules/eslint/node_modules/path-key": {
       "version": "3.1.1",
@@ -13282,11 +12886,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/eslint/node_modules/yallist": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/espree": {
       "version": "7.3.1",
@@ -17511,14 +17110,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/jest-message-util/node_modules/slash": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/jest-message-util/node_modules/supports-color": {
       "version": "7.2.0",
       "dev": true,
@@ -17684,14 +17275,6 @@
       "version": "0.6.0",
       "dev": true,
       "license": "(MIT OR CC0-1.0)",
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/jest-resolve/node_modules/slash": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
       "engines": {
         "node": ">=8"
       }
@@ -17894,14 +17477,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/jest-runtime/node_modules/slash": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/jest-runtime/node_modules/supports-color": {
       "version": "7.2.0",
       "dev": true,
@@ -18004,17 +17579,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/jest-snapshot/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/jest-snapshot/node_modules/semver": {
       "version": "7.3.5",
       "dev": true,
@@ -18039,11 +17603,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/jest-snapshot/node_modules/yallist": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/jest-util": {
       "version": "26.6.2",
@@ -19680,9 +19239,10 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.5",
-      "dev": true,
-      "license": "MIT"
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
+      "dev": true
     },
     "node_modules/minimist-options": {
       "version": "4.1.0",
@@ -20084,18 +19644,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/node-notifier/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "dev": true,
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/node-notifier/node_modules/semver": {
       "version": "7.3.5",
       "dev": true,
@@ -20125,12 +19673,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/node-notifier/node_modules/yallist": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "ISC",
-      "optional": true
     },
     "node_modules/node-releases": {
       "version": "1.1.77",
@@ -22980,15 +22522,6 @@
       "version": "17.0.2",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/react-test-renderer/node_modules/scheduler": {
-      "version": "0.20.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
-      }
     },
     "node_modules/react-textarea-autosize": {
       "version": "8.3.2",
@@ -25910,14 +25443,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/stylelint/node_modules/array-union": {
-      "version": "2.1.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/stylelint/node_modules/astral-regex": {
       "version": "2.0.0",
       "dev": true,
@@ -25973,24 +25498,8 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/stylelint/node_modules/dir-glob": {
-      "version": "3.0.1",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "path-type": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/stylelint/node_modules/emoji-regex": {
       "version": "8.0.0",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/stylelint/node_modules/fast-deep-equal": {
-      "version": "3.1.3",
       "dev": true,
       "license": "MIT"
     },
@@ -26037,25 +25546,6 @@
       "version": "3.1.1",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/stylelint/node_modules/globby": {
-      "version": "11.0.3",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "array-union": "^2.1.0",
-        "dir-glob": "^3.0.1",
-        "fast-glob": "^3.1.1",
-        "ignore": "^5.1.4",
-        "merge2": "^1.3.0",
-        "slash": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/stylelint/node_modules/has-flag": {
       "version": "4.0.0",
@@ -26110,17 +25600,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/stylelint/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/stylelint/node_modules/map-obj": {
@@ -26286,14 +25765,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/stylelint/node_modules/slash": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/stylelint/node_modules/slice-ansi": {
       "version": "4.0.0",
       "dev": true,
@@ -26368,11 +25839,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/stylelint/node_modules/yallist": {
-      "version": "4.0.0",
-      "dev": true,
-      "license": "ISC"
     },
     "node_modules/stylelint/node_modules/yargs-parser": {
       "version": "20.2.7",
@@ -30611,10 +30077,6 @@
           "version": "4.0.0",
           "dev": true
         },
-        "slash": {
-          "version": "3.0.0",
-          "dev": true
-        },
         "supports-color": {
           "version": "7.2.0",
           "dev": true,
@@ -30698,10 +30160,6 @@
           "requires": {
             "glob": "^7.1.3"
           }
-        },
-        "slash": {
-          "version": "3.0.0",
-          "dev": true
         },
         "strip-ansi": {
           "version": "6.0.0",
@@ -30811,10 +30269,6 @@
           "version": "4.0.0",
           "dev": true
         },
-        "slash": {
-          "version": "3.0.0",
-          "dev": true
-        },
         "source-map": {
           "version": "0.6.1",
           "dev": true
@@ -30913,10 +30367,6 @@
         },
         "has-flag": {
           "version": "4.0.0",
-          "dev": true
-        },
-        "slash": {
-          "version": "3.0.0",
           "dev": true
         },
         "source-map": {
@@ -33067,36 +32517,6 @@
             "@babel/highlight": "^7.12.13"
           }
         },
-        "@jest/types": {
-          "version": "26.6.2",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-coverage": "^2.0.0",
-            "@types/istanbul-reports": "^3.0.0",
-            "@types/node": "*",
-            "@types/yargs": "^15.0.0",
-            "chalk": "^4.0.0"
-          }
-        },
-        "@types/istanbul-reports": {
-          "version": "3.0.0",
-          "dev": true,
-          "requires": {
-            "@types/istanbul-lib-report": "*"
-          }
-        },
-        "ansi-regex": {
-          "version": "5.0.0",
-          "dev": true
-        },
-        "aria-query": {
-          "version": "4.2.2",
-          "dev": true,
-          "requires": {
-            "@babel/runtime": "^7.10.2",
-            "@babel/runtime-corejs3": "^7.10.2"
-          }
-        },
         "chalk": {
           "version": "4.1.1",
           "dev": true,
@@ -33135,29 +32555,6 @@
         "has-flag": {
           "version": "4.0.0",
           "dev": true
-        },
-        "pretty-format": {
-          "version": "26.6.2",
-          "dev": true,
-          "requires": {
-            "@jest/types": "^26.6.2",
-            "ansi-regex": "^5.0.0",
-            "ansi-styles": "^4.0.0",
-            "react-is": "^17.0.1"
-          },
-          "dependencies": {
-            "ansi-styles": {
-              "version": "4.3.0",
-              "dev": true,
-              "requires": {
-                "color-convert": "^2.0.1"
-              }
-            }
-          }
-        },
-        "react-is": {
-          "version": "17.0.2",
-          "dev": true
         }
       }
     },
@@ -33180,14 +32577,6 @@
           "dev": true,
           "requires": {
             "color-convert": "^2.0.1"
-          }
-        },
-        "aria-query": {
-          "version": "4.2.2",
-          "dev": true,
-          "requires": {
-            "@babel/runtime": "^7.10.2",
-            "@babel/runtime-corejs3": "^7.10.2"
           }
         },
         "chalk": {
@@ -33752,70 +33141,12 @@
         "tsutils": "^3.17.1"
       },
       "dependencies": {
-        "@nodelib/fs.stat": {
-          "version": "2.0.4",
-          "dev": true
-        },
-        "array-union": {
-          "version": "2.1.0",
-          "dev": true
-        },
-        "dir-glob": {
-          "version": "3.0.1",
-          "dev": true,
-          "requires": {
-            "path-type": "^4.0.0"
-          }
-        },
-        "fast-glob": {
-          "version": "3.2.5",
-          "dev": true,
-          "requires": {
-            "@nodelib/fs.stat": "^2.0.2",
-            "@nodelib/fs.walk": "^1.2.3",
-            "glob-parent": "^5.1.0",
-            "merge2": "^1.3.0",
-            "micromatch": "^4.0.2",
-            "picomatch": "^2.2.1"
-          }
-        },
-        "globby": {
-          "version": "11.0.3",
-          "dev": true,
-          "requires": {
-            "array-union": "^2.1.0",
-            "dir-glob": "^3.0.1",
-            "fast-glob": "^3.1.1",
-            "ignore": "^5.1.4",
-            "merge2": "^1.3.0",
-            "slash": "^3.0.0"
-          }
-        },
-        "ignore": {
-          "version": "5.1.8",
-          "dev": true
-        },
-        "lru-cache": {
-          "version": "6.0.0",
-          "dev": true,
-          "requires": {
-            "yallist": "^4.0.0"
-          }
-        },
         "semver": {
           "version": "7.3.5",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
           }
-        },
-        "slash": {
-          "version": "3.0.0",
-          "dev": true
-        },
-        "yallist": {
-          "version": "4.0.0",
-          "dev": true
         }
       }
     },
@@ -34541,10 +33872,6 @@
         },
         "has-flag": {
           "version": "4.0.0",
-          "dev": true
-        },
-        "slash": {
-          "version": "3.0.0",
           "dev": true
         },
         "supports-color": {
@@ -36485,13 +35812,6 @@
             "json5": "^2.1.2"
           }
         },
-        "lru-cache": {
-          "version": "6.0.0",
-          "dev": true,
-          "requires": {
-            "yallist": "^4.0.0"
-          }
-        },
         "postcss": {
           "version": "8.2.15",
           "dev": true,
@@ -36538,10 +35858,6 @@
         },
         "source-map": {
           "version": "0.6.1",
-          "dev": true
-        },
-        "yallist": {
-          "version": "4.0.0",
           "dev": true
         }
       }
@@ -37751,10 +37067,6 @@
           "version": "2.1.0",
           "dev": true
         },
-        "fast-deep-equal": {
-          "version": "3.1.3",
-          "dev": true
-        },
         "file-entry-cache": {
           "version": "6.0.1",
           "dev": true,
@@ -37792,13 +37104,6 @@
         "json-schema-traverse": {
           "version": "1.0.0",
           "dev": true
-        },
-        "lru-cache": {
-          "version": "6.0.0",
-          "dev": true,
-          "requires": {
-            "yallist": "^4.0.0"
-          }
         },
         "path-key": {
           "version": "3.1.1",
@@ -37895,10 +37200,6 @@
           "requires": {
             "isexe": "^2.0.0"
           }
-        },
-        "yallist": {
-          "version": "4.0.0",
-          "dev": true
         }
       }
     },
@@ -38087,10 +37388,6 @@
         "@typescript-eslint/experimental-utils": "^4.24.0"
       },
       "dependencies": {
-        "@nodelib/fs.stat": {
-          "version": "2.0.5",
-          "dev": true
-        },
         "@typescript-eslint/experimental-utils": {
           "version": "4.28.1",
           "dev": true,
@@ -38136,24 +37433,6 @@
             "eslint-visitor-keys": "^2.0.0"
           }
         },
-        "array-union": {
-          "version": "2.1.0",
-          "dev": true
-        },
-        "debug": {
-          "version": "4.3.1",
-          "dev": true,
-          "requires": {
-            "ms": "2.1.2"
-          }
-        },
-        "dir-glob": {
-          "version": "3.0.1",
-          "dev": true,
-          "requires": {
-            "path-type": "^4.0.0"
-          }
-        },
         "eslint-scope": {
           "version": "5.1.1",
           "dev": true,
@@ -38173,74 +37452,12 @@
           "version": "2.1.0",
           "dev": true
         },
-        "esrecurse": {
-          "version": "4.3.0",
-          "dev": true,
-          "requires": {
-            "estraverse": "^5.2.0"
-          },
-          "dependencies": {
-            "estraverse": {
-              "version": "5.2.0",
-              "dev": true
-            }
-          }
-        },
-        "fast-glob": {
-          "version": "3.2.6",
-          "dev": true,
-          "requires": {
-            "@nodelib/fs.stat": "^2.0.2",
-            "@nodelib/fs.walk": "^1.2.3",
-            "glob-parent": "^5.1.2",
-            "merge2": "^1.3.0",
-            "micromatch": "^4.0.4"
-          }
-        },
-        "globby": {
-          "version": "11.0.4",
-          "dev": true,
-          "requires": {
-            "array-union": "^2.1.0",
-            "dir-glob": "^3.0.1",
-            "fast-glob": "^3.1.1",
-            "ignore": "^5.1.4",
-            "merge2": "^1.3.0",
-            "slash": "^3.0.0"
-          }
-        },
-        "ignore": {
-          "version": "5.1.8",
-          "dev": true
-        },
-        "lru-cache": {
-          "version": "6.0.0",
-          "dev": true,
-          "requires": {
-            "yallist": "^4.0.0"
-          }
-        },
         "semver": {
           "version": "7.3.5",
           "dev": true,
           "requires": {
             "lru-cache": "^6.0.0"
           }
-        },
-        "slash": {
-          "version": "3.0.0",
-          "dev": true
-        },
-        "tsutils": {
-          "version": "3.21.0",
-          "dev": true,
-          "requires": {
-            "tslib": "^1.8.1"
-          }
-        },
-        "yallist": {
-          "version": "4.0.0",
-          "dev": true
         }
       }
     },
@@ -41126,10 +40343,6 @@
           "version": "4.0.0",
           "dev": true
         },
-        "slash": {
-          "version": "3.0.0",
-          "dev": true
-        },
         "supports-color": {
           "version": "7.2.0",
           "dev": true,
@@ -41224,10 +40437,6 @@
             "read-pkg": "^5.2.0",
             "type-fest": "^0.8.1"
           }
-        },
-        "slash": {
-          "version": "3.0.0",
-          "dev": true
         },
         "supports-color": {
           "version": "7.2.0",
@@ -41375,10 +40584,6 @@
           "version": "4.0.0",
           "dev": true
         },
-        "slash": {
-          "version": "3.0.0",
-          "dev": true
-        },
         "supports-color": {
           "version": "7.2.0",
           "dev": true,
@@ -41448,13 +40653,6 @@
           "version": "4.0.0",
           "dev": true
         },
-        "lru-cache": {
-          "version": "6.0.0",
-          "dev": true,
-          "requires": {
-            "yallist": "^4.0.0"
-          }
-        },
         "semver": {
           "version": "7.3.5",
           "dev": true,
@@ -41468,10 +40666,6 @@
           "requires": {
             "has-flag": "^4.0.0"
           }
-        },
-        "yallist": {
-          "version": "4.0.0",
-          "dev": true
         }
       }
     },
@@ -42584,7 +41778,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "dev": true
     },
     "minimist-options": {
@@ -42906,14 +42102,6 @@
             "is-docker": "^2.0.0"
           }
         },
-        "lru-cache": {
-          "version": "6.0.0",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "yallist": "^4.0.0"
-          }
-        },
         "semver": {
           "version": "7.3.5",
           "dev": true,
@@ -42929,11 +42117,6 @@
           "requires": {
             "isexe": "^2.0.0"
           }
-        },
-        "yallist": {
-          "version": "4.0.0",
-          "dev": true,
-          "optional": true
         }
       }
     },
@@ -45006,14 +44189,6 @@
         "react-is": {
           "version": "17.0.2",
           "dev": true
-        },
-        "scheduler": {
-          "version": "0.20.2",
-          "dev": true,
-          "requires": {
-            "loose-envify": "^1.1.0",
-            "object-assign": "^4.1.1"
-          }
         }
       }
     },
@@ -47040,10 +46215,6 @@
             "color-convert": "^2.0.1"
           }
         },
-        "array-union": {
-          "version": "2.1.0",
-          "dev": true
-        },
         "astral-regex": {
           "version": "2.0.0",
           "dev": true
@@ -47076,19 +46247,8 @@
           "version": "1.1.4",
           "dev": true
         },
-        "dir-glob": {
-          "version": "3.0.1",
-          "dev": true,
-          "requires": {
-            "path-type": "^4.0.0"
-          }
-        },
         "emoji-regex": {
           "version": "8.0.0",
-          "dev": true
-        },
-        "fast-deep-equal": {
-          "version": "3.1.3",
           "dev": true
         },
         "fast-glob": {
@@ -47122,18 +46282,6 @@
           "version": "3.1.1",
           "dev": true
         },
-        "globby": {
-          "version": "11.0.3",
-          "dev": true,
-          "requires": {
-            "array-union": "^2.1.0",
-            "dir-glob": "^3.0.1",
-            "fast-glob": "^3.1.1",
-            "ignore": "^5.1.4",
-            "merge2": "^1.3.0",
-            "slash": "^3.0.0"
-          }
-        },
         "has-flag": {
           "version": "4.0.0",
           "dev": true
@@ -47163,13 +46311,6 @@
           "requires": {
             "chalk": "^4.1.0",
             "is-unicode-supported": "^0.1.0"
-          }
-        },
-        "lru-cache": {
-          "version": "6.0.0",
-          "dev": true,
-          "requires": {
-            "yallist": "^4.0.0"
           }
         },
         "map-obj": {
@@ -47275,10 +46416,6 @@
             "lru-cache": "^6.0.0"
           }
         },
-        "slash": {
-          "version": "3.0.0",
-          "dev": true
-        },
         "slice-ansi": {
           "version": "4.0.0",
           "dev": true,
@@ -47325,10 +46462,6 @@
         },
         "trim-newlines": {
           "version": "3.0.0",
-          "dev": true
-        },
-        "yallist": {
-          "version": "4.0.0",
           "dev": true
         },
         "yargs-parser": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,8 +57,12 @@ import ProgressBar, {
 } from "./progress-bar/ProgressBar";
 import {DateTimerProps as DateTimerComponentProps} from "./date-timer/util/dateTimerTypes";
 import Toast, {ToastProps as ToastComponentProps} from "./toast/Toast";
-import {useToastContext, useToaster} from "./toast/util/toastHooks";
-import {ToastContext, ToastContextProvider} from "./toast/ToastProvider";
+import {useToastState, useToaster} from "./toast/util/toastHooks";
+import {
+  ToastDispatchContext,
+  ToastStateContext,
+  ToastContextProvider
+} from "./toast/ToastProvider";
 
 export {
   // Components
@@ -86,11 +90,12 @@ export {
   Switch,
   Toast,
   // Hooks
-  useToastContext,
+  useToastState,
   useToaster,
   useDateTimer,
   // Contexts
-  ToastContext,
+  ToastDispatchContext,
+  ToastStateContext,
   ToastContextProvider
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,7 +57,7 @@ import ProgressBar, {
 } from "./progress-bar/ProgressBar";
 import {DateTimerProps as DateTimerComponentProps} from "./date-timer/util/dateTimerTypes";
 import Toast, {ToastProps as ToastComponentProps} from "./toast/Toast";
-import {useToastState, useToaster} from "./toast/util/toastHooks";
+import {useToastContextState, useToaster} from "./toast/util/toastHooks";
 import {
   ToastDispatchContext,
   ToastStateContext,
@@ -90,7 +90,7 @@ export {
   Switch,
   Toast,
   // Hooks
-  useToastState,
+  useToastContextState,
   useToaster,
   useDateTimer,
   // Contexts

--- a/src/toast/Toast.tsx
+++ b/src/toast/Toast.tsx
@@ -1,7 +1,7 @@
 import React, {useLayoutEffect} from "react";
 import classNames from "classnames";
 
-import {useToaster, useToastState} from "./util/toastHooks";
+import {useToaster, useToastContextState} from "./util/toastHooks";
 import {ToastContextState} from "./util/toastTypes";
 import ListItem from "../list/item/ListItem";
 import ToastCloseButton from "./close-button/ToastCloseButton";
@@ -13,7 +13,7 @@ export interface ToastProps {
 }
 
 function Toast({testid, data}: ToastProps) {
-  const contextState = useToastState();
+  const contextState = useToastContextState();
   const {hide} = useToaster();
   const {
     timeout = contextState.defaultAutoCloseTimeout,

--- a/src/toast/Toast.tsx
+++ b/src/toast/Toast.tsx
@@ -1,7 +1,7 @@
 import React, {useLayoutEffect} from "react";
 import classNames from "classnames";
 
-import {useToaster, useToastContext} from "./util/toastHooks";
+import {useToaster, useToastState} from "./util/toastHooks";
 import {ToastContextState} from "./util/toastTypes";
 import ListItem from "../list/item/ListItem";
 import ToastCloseButton from "./close-button/ToastCloseButton";
@@ -13,7 +13,7 @@ export interface ToastProps {
 }
 
 function Toast({testid, data}: ToastProps) {
-  const [contextState] = useToastContext();
+  const contextState = useToastState();
   const {hide} = useToaster();
   const {
     timeout = contextState.defaultAutoCloseTimeout,

--- a/src/toast/ToastProvider.tsx
+++ b/src/toast/ToastProvider.tsx
@@ -6,8 +6,8 @@ import toastReducer from "./util/toastReducer";
 import {ToastAction, ToastContextState} from "./util/toastTypes";
 import {isNonNegativeNumber} from "../core/utils/number/numberUtils";
 
-const ToastStateContext = createContext<ToastContextState>(initialToastState);
-const ToastDispatchContext = createContext<React.Dispatch<ToastAction>>(() => undefined);
+const ToastStateContext = createContext<null | ToastContextState>(null);
+const ToastDispatchContext = createContext<null | React.Dispatch<ToastAction>>(null);
 
 ToastDispatchContext.displayName = "ToastDispatchContext";
 ToastStateContext.displayName = "ToastStateContext";

--- a/src/toast/ToastProvider.tsx
+++ b/src/toast/ToastProvider.tsx
@@ -6,12 +6,11 @@ import toastReducer from "./util/toastReducer";
 import {ToastAction, ToastContextState} from "./util/toastTypes";
 import {isNonNegativeNumber} from "../core/utils/number/numberUtils";
 
-const ToastContext = createContext<[ToastContextState, React.Dispatch<ToastAction>]>([
-  initialToastState,
-  () => undefined
-]);
+const ToastStateContext = createContext<ToastContextState>(initialToastState);
+const ToastDispatchContext = createContext<React.Dispatch<ToastAction>>(() => undefined);
 
-ToastContext.displayName = "ToastContext";
+ToastDispatchContext.displayName = "ToastDispatchContext";
+ToastStateContext.displayName = "ToastStateContext";
 
 interface ToastContextProviderProps {
   children: React.ReactNode;
@@ -58,12 +57,14 @@ function ToastContextProvider({
   }, [defaultAutoCloseTimeout]);
 
   return (
-    <ToastContext.Provider value={[state, dispatch]}>
-      {children}
+    <ToastStateContext.Provider value={state}>
+      <ToastDispatchContext.Provider value={dispatch}>
+        {children}
 
-      <ToastStack customRootId={customRootId} />
-    </ToastContext.Provider>
+        <ToastStack customRootId={customRootId} />
+      </ToastDispatchContext.Provider>
+    </ToastStateContext.Provider>
   );
 }
 
-export {ToastContext, ToastContextProvider};
+export {ToastDispatchContext, ToastStateContext, ToastContextProvider};

--- a/src/toast/stack/ToastStack.tsx
+++ b/src/toast/stack/ToastStack.tsx
@@ -5,14 +5,14 @@ import ReactDOM from "react-dom";
 
 import List from "../../list/List";
 import Toast from "../Toast";
-import {useToastState} from "../util/toastHooks";
+import {useToastContextState} from "../util/toastHooks";
 
 interface ToastStackProps {
   customRootId?: string;
 }
 
 function ToastStack({customRootId}: ToastStackProps) {
-  const state = useToastState();
+  const state = useToastContextState();
   const [rootNode, setRootNode] = useState<null | Element>(null);
 
   useLayoutEffect(() => {

--- a/src/toast/stack/ToastStack.tsx
+++ b/src/toast/stack/ToastStack.tsx
@@ -5,14 +5,14 @@ import ReactDOM from "react-dom";
 
 import List from "../../list/List";
 import Toast from "../Toast";
-import {useToastContext} from "../util/toastHooks";
+import {useToastState} from "../util/toastHooks";
 
 interface ToastStackProps {
   customRootId?: string;
 }
 
 function ToastStack({customRootId}: ToastStackProps) {
-  const [state] = useToastContext();
+  const state = useToastState();
   const [rootNode, setRootNode] = useState<null | Element>(null);
 
   useLayoutEffect(() => {

--- a/src/toast/util/toastHooks.ts
+++ b/src/toast/util/toastHooks.ts
@@ -21,6 +21,10 @@ function useToastContextState(): ToastContextState {
 function useToaster() {
   const dispatch = useContext(ToastDispatchContext);
 
+  if (!dispatch) {
+    throw new Error("Trying to consume ToastDispatchContext outside of its provider");
+  }
+
   return {
     /**
      * Display a Toast

--- a/src/toast/util/toastHooks.ts
+++ b/src/toast/util/toastHooks.ts
@@ -2,27 +2,24 @@ import {useCallback, useContext} from "react";
 
 import {generateRandomString} from "../../core/utils/string/stringUtils";
 import {ToastItemContext} from "../ToastItemContext";
-import {ToastContext} from "../ToastProvider";
-import {ToastData} from "./toastTypes";
+import {ToastDispatchContext, ToastStateContext} from "../ToastProvider";
+import {ToastContextState, ToastData} from "./toastTypes";
 
 /**
- * @returns {Object} Current value of ToastContext
+ * @returns {Object} Current value of ToastContextState
  */
-function useToastContext() {
-  const context = useContext(ToastContext);
+function useToastState(): ToastContextState {
+  const state = useContext(ToastStateContext);
 
-  if (!context) {
+  if (!state) {
     throw new Error("Trying to consume ToastContext outside of its provider.");
   }
 
-  return context;
+  return state;
 }
 
-/**
- * @returns {function} ToastContext's state reducer's dispatch function
- */
 function useToaster() {
-  const dispatch = useToastContext()[1];
+  const dispatch = useContext(ToastDispatchContext);
 
   return {
     /**
@@ -91,4 +88,4 @@ function useToastItemContext() {
   return toastStoryContext;
 }
 
-export {useToastContext, useToaster, useToastItemContext};
+export {useToastState, useToaster, useToastItemContext};

--- a/src/toast/util/toastHooks.ts
+++ b/src/toast/util/toastHooks.ts
@@ -8,11 +8,11 @@ import {ToastContextState, ToastData} from "./toastTypes";
 /**
  * @returns {Object} Current value of ToastContextState
  */
-function useToastState(): ToastContextState {
+function useToastContextState(): ToastContextState {
   const state = useContext(ToastStateContext);
 
   if (!state) {
-    throw new Error("Trying to consume ToastContext outside of its provider.");
+    throw new Error("Trying to consume ToastStateContext outside of its provider.");
   }
 
   return state;
@@ -79,13 +79,13 @@ function useToaster() {
 }
 
 function useToastItemContext() {
-  const toastStoryContext = useContext(ToastItemContext);
+  const toastItemContext = useContext(ToastItemContext);
 
-  if (!toastStoryContext) {
+  if (!toastItemContext) {
     throw new Error("Trying to consume ToastItemContext outside of its provider");
   }
 
-  return toastStoryContext;
+  return toastItemContext;
 }
 
-export {useToastState, useToaster, useToastItemContext};
+export {useToastContextState, useToaster, useToastItemContext};


### PR DESCRIPTION
### What is the problem?
  -  In our apps, we mostly only care Toast state `dispatch` function. But in the current implementation, since `useToaster` returns both state and dispatch in the same object, dispatch function will "change" on every state change, and this will cause re-render in the components that use `dispatch`.

### Possible (implemented) Solution
  - Separating state and dispatch contexts, so that state changes won't trigger a change in `dispatch`
 
### Result (before vs after) [green border means that element is re-rendered]
I tried on my local with `npm-link`, here is the result:
https://user-images.githubusercontent.com/22727931/175345592-35eadfd1-6b05-4a3d-9334-7320a0e95f32.mov
Only necessary elements re-renders. As expected.

**If the app is only using `useToaster`, it won't be a breaking change and won't require any changes on the project**

