### PR TITLE
fix(build): fix timeinput component path in rollup config

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -32,7 +32,7 @@ export default [
       Toggle: "src/toggle/Toggle.tsx",
       Switch: "src/switch/Switch.tsx",
       ProgressBar: "src/progress-bar/ProgressBar.tsx",
-      TimeInput: "src/form/time/TimeInput.tsx",
+      TimeInput: "src/form/time-input/TimeInput.tsx",
       DateTimer: "src/date-timer/DateTimer.tsx"
     },
     output: {


### PR DESCRIPTION
This was causing error while building. I guess we decided to change the folder name but forgot to update the rollup config.

Will merge right now since it's a straightforward path fix.