### PR TITLE
build: Add a new workflow that deploys PR previews

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,34 @@
+name: Deploy PR previews to GitHub Pages
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - closed
+
+concurrency: preview-${{ github.ref }}
+
+jobs:
+  deploy-preview:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14
+
+      - name: Install dependencies and build storybook
+        run: |
+          npm install
+          npm run storybook:build
+
+      - name: Deploy storybook build to GitHub Pages
+        uses: rossjrw/pr-preview-action@v1
+        with:
+          source-dir: ./public/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@hipo/react-ui-toolkit",
-  "version": "1.0.0-beta.1.1.0",
+  "version": "1.0.0-beta.1.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hipo/react-ui-toolkit",
-  "version": "1.0.0-beta.1.1.0",
+  "version": "1.0.0-beta.1.1.1",
   "description": "React based UI toolkit.",
   "main": "dist/index.js",
   "scripts": {


### PR DESCRIPTION
In case of a change of PR (including opening a new PR), this new workflow automatically:
- Builds storybook and deploys it to GitHub Pages
  - It uses `gh-pages` branch for deployments
- Posts a link of preview build to PR
  - Example link: https://jamcry.github.io/react-ui-toolkit/pr-preview/pr-3/
- After PR is closed, it removes the build files, and updates the comment of the PR

### Notes
- Uses: [rossjrw/pr-preview-action@v1](https://github.com/rossjrw/pr-preview-action)
- Check my forked repo for example: https://github.com/jamcry/react-ui-toolkit
- The main reason why we wanted this kind of solution is to be able to test new changes before sending it to production.

### TODO
- [x] We need to activate GitHub Pages for the repo and configure it like this (I don't have permission to do this):
<img width="343" alt="Screenshot 2022-09-02 at 11 18 15" src="https://user-images.githubusercontent.com/22727931/188107523-1a61d451-77c4-4293-bdc3-00a7c0f0b994.png">


## Example images
![image](https://user-images.githubusercontent.com/22727931/188105561-d310e251-483f-4e15-9fc8-a5d899e81e2c.png)
![image](https://user-images.githubusercontent.com/22727931/188105580-5bb1db53-c2ef-48e0-8df6-a6c086d0c06f.png)
