### PR TITLE
fix(tab): out of bounds issue for screen size change 

### DIFF
--- a/src/core/utils/hooks/useWindowSize.tsx
+++ b/src/core/utils/hooks/useWindowSize.tsx
@@ -5,17 +5,16 @@ interface Size {
   height: number | undefined;
 }
 function useWindowSize(): Size {
-
   const [windowSize, setWindowSize] = useState<Size>({
     width: undefined,
-    height: undefined,
+    height: undefined
   });
 
   useEffect(() => {
     function handleResize() {
       setWindowSize({
         width: window.innerWidth,
-        height: window.innerHeight,
+        height: window.innerHeight
       });
     }
     window.addEventListener("resize", handleResize);

--- a/src/core/utils/hooks/useWindowSize.tsx
+++ b/src/core/utils/hooks/useWindowSize.tsx
@@ -1,0 +1,28 @@
+import {useState, useEffect} from "react";
+// Define general type for useWindowSize hook, which includes width and height
+interface Size {
+  width: number | undefined;
+  height: number | undefined;
+}
+function useWindowSize(): Size {
+
+  const [windowSize, setWindowSize] = useState<Size>({
+    width: undefined,
+    height: undefined,
+  });
+
+  useEffect(() => {
+    function handleResize() {
+      setWindowSize({
+        width: window.innerWidth,
+        height: window.innerHeight,
+      });
+    }
+    window.addEventListener("resize", handleResize);
+    handleResize();
+    return () => window.removeEventListener("resize", handleResize);
+  }, []);
+  return windowSize;
+}
+
+export default useWindowSize;

--- a/src/tab/Tab.tsx
+++ b/src/tab/Tab.tsx
@@ -49,9 +49,8 @@ function Tab({
   const [activeTabIndex, setActiveTabIndex] = useState(initialActiveTabIndex);
   const tabClassName = classNames("tab", customClassName);
 
-  let activeTabIndexToUse =
-    activeTabIndexFromProps === undefined ? activeTabIndex : activeTabIndexFromProps;
-
+  let activeTabIndexToUse = activeTabIndexFromProps || activeTabIndex;
+  
   /**
    * In case activeTabIndex is out of bounds, we need to reset it to 0.
    * This can happen if items are changes after the mount

--- a/src/tab/Tab.tsx
+++ b/src/tab/Tab.tsx
@@ -26,14 +26,14 @@ interface UncontrolledTabProps {
 // and initialActiveTabIndex should be undefined
 type ControlledTabProps =
   | {
-    activeTabIndex: number;
-    onTabChange: (index: number) => void;
-    initialActiveTabIndex?: number;
-  }
+      activeTabIndex: number;
+      onTabChange: (index: number) => void;
+      initialActiveTabIndex?: number;
+    }
   | {
-    activeTabIndex?: number;
-    onTabChange?: (index: number) => void;
-  };
+      activeTabIndex?: number;
+      onTabChange?: (index: number) => void;
+    };
 
 export type TabProps = ControlledTabProps & UncontrolledTabProps;
 
@@ -49,12 +49,16 @@ function Tab({
   const [activeTabIndex, setActiveTabIndex] = useState(initialActiveTabIndex);
   const tabClassName = classNames("tab", customClassName);
 
-  let activeTabIndexToUse = activeTabIndexFromProps === undefined
-    ? activeTabIndex
-    : activeTabIndexFromProps;
+  let activeTabIndexToUse =
+    activeTabIndexFromProps === undefined ? activeTabIndex : activeTabIndexFromProps;
 
-  // check if active index is out of bounds
-  activeTabIndexToUse = activeTabIndexToUse > items.length ? 0 : activeTabIndexToUse;
+  /**
+   * In case activeTabIndex is out of bounds, we need to reset it to 0.
+   * This can happen if items are changes after the mount
+   */
+  if (activeTabIndexToUse > items.length) {
+    activeTabIndexToUse = 0;
+  }
 
   return (
     <div className={tabClassName}>
@@ -64,20 +68,14 @@ function Tab({
             testid={itemTestId}
             onClick={handleChangeActiveTab}
             tab={item}
-            isActive={
-              activeTabIndexToUse === index
-            }
+            isActive={activeTabIndexToUse === index}
             index={index!}
           />
         )}
       </List>
 
       <div className={"tab__body"} data-testid={`${testid}.body`}>
-        {
-          children[
-          activeTabIndexToUse
-          ]
-        }
+        {children[activeTabIndexToUse]}
       </div>
     </div>
   );

--- a/src/tab/Tab.tsx
+++ b/src/tab/Tab.tsx
@@ -26,14 +26,14 @@ interface UncontrolledTabProps {
 // and initialActiveTabIndex should be undefined
 type ControlledTabProps =
   | {
-      activeTabIndex: number;
-      onTabChange: (index: number) => void;
-      initialActiveTabIndex?: number;
-    }
+    activeTabIndex: number;
+    onTabChange: (index: number) => void;
+    initialActiveTabIndex?: number;
+  }
   | {
-      activeTabIndex?: number;
-      onTabChange?: (index: number) => void;
-    };
+    activeTabIndex?: number;
+    onTabChange?: (index: number) => void;
+  };
 
 export type TabProps = ControlledTabProps & UncontrolledTabProps;
 
@@ -49,6 +49,13 @@ function Tab({
   const [activeTabIndex, setActiveTabIndex] = useState(initialActiveTabIndex);
   const tabClassName = classNames("tab", customClassName);
 
+  let activeTabIndexToUse = activeTabIndexFromProps === undefined
+    ? activeTabIndex
+    : activeTabIndexFromProps;
+
+  // check if active index is out of bounds
+  activeTabIndexToUse = activeTabIndexToUse > items.length ? 0 : activeTabIndexToUse;
+
   return (
     <div className={tabClassName}>
       <List testid={`${testid}.header`} customClassName={"tab__header"} items={items}>
@@ -58,9 +65,7 @@ function Tab({
             onClick={handleChangeActiveTab}
             tab={item}
             isActive={
-              activeTabIndexFromProps === undefined
-                ? activeTabIndex === index
-                : activeTabIndexFromProps === index
+              activeTabIndexToUse === index
             }
             index={index!}
           />
@@ -70,9 +75,7 @@ function Tab({
       <div className={"tab__body"} data-testid={`${testid}.body`}>
         {
           children[
-            activeTabIndexFromProps === undefined
-              ? activeTabIndex
-              : activeTabIndexFromProps
+          activeTabIndexToUse
           ]
         }
       </div>


### PR DESCRIPTION
**Related Issue;**
- #193 

I tried recreate problem by updating the `items` (it had 5 elements, I changed it to 2) for screens smaller than 400, using `useWindowSize` (this will be removed, only there for testing purposes). 

https://user-images.githubusercontent.com/53620159/215018788-d145f0d4-380b-4ad1-97a8-65130e5b4ce0.mov

After adding the out of bounds check and setting `index` to 0:

https://user-images.githubusercontent.com/53620159/215018981-7921809a-4271-4f37-8599-da6b75a606af.mov

